### PR TITLE
Feat/be-curationPost 큐레이션 작성 기능 추가

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -1,0 +1,39 @@
+package com.seb_main_004.whosbook.curation.controller;
+
+import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.curation.mapper.CurationMapper;
+import com.seb_main_004.whosbook.curation.service.CurationService;
+import com.seb_main_004.whosbook.utils.UriCreator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@Slf4j
+@Validated
+@RequestMapping("/curations")
+
+public class CurationController {
+    private final CurationService curationService;
+    private final CurationMapper mapper;
+    private final String CURATION_DEFAULT_URL = "/curations";
+
+    public CurationController(CurationService curationService, CurationMapper mapper) {
+        this.curationService = curationService;
+        this.mapper = mapper;
+    }
+
+    @PostMapping
+    public ResponseEntity postCuration(@RequestBody @Valid CurationPostDto postDto){
+        Curation savedCuration = curationService.createCuration(mapper.curationPostDtoToCuration(postDto));
+        URI uri = UriCreator.createUri(CURATION_DEFAULT_URL, savedCuration.getCurationId());
+        return ResponseEntity.created(uri).build();
+    }
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
@@ -1,0 +1,28 @@
+package com.seb_main_004.whosbook.curation.dto;
+
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+@Builder
+@Getter
+public class CurationPostDto {
+    @Positive
+    private long memberId;
+    @NotBlank
+    @Length(max = 5)
+    private String emoji;
+    @NotBlank
+    @Length(min = 1, max = 30)
+    private String title;
+    @NotBlank
+    @Length(min = 10)
+    private String content;
+    @NotNull
+    private Curation.Visibility visibility;
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -3,12 +3,8 @@ package com.seb_main_004.whosbook.curation.entity;
 
 import lombok.Data;
 import lombok.Getter;
-import lombok.Setter;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
@@ -17,20 +13,31 @@ public class Curation {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long curationId;
+    @Column(nullable = false, length = 5)
+    private String emoji;
 
+    @Column(nullable = false, length = 30)
     private String title;
 
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    private LocalDateTime createdAt=LocalDateTime.now();
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private Visibility visibilityStatus = Visibility.PUBLIC;
 
-    private LocalDateTime updatedAt=LocalDateTime.now();
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false)
+    private CurationStatus curationStatus = CurationStatus.CURATION_ACTIVE;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
 
 
-    private Visibility visibilityStatus= Visibility.PUBLIC;
-
-
-    public  enum  Visibility{
+    public enum Visibility{
 
         PUBLIC("공개"),
         SECRET("비공개");
@@ -43,7 +50,7 @@ public class Curation {
         }
     }
 
-    public  enum CurationStatus{
+    public enum CurationStatus{
 
         CURATION_DELETE("삭제된 글"),
         CURATION_ACTIVE("게시 중인 글");

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -1,0 +1,12 @@
+package com.seb_main_004.whosbook.curation.mapper;
+
+import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CurationMapper {
+    @Mapping(source = "visibility", target = "visibilityStatus")
+    Curation curationPostDtoToCuration(CurationPostDto postDto);
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
@@ -1,0 +1,7 @@
+package com.seb_main_004.whosbook.curation.repository;
+
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CurationRepository extends JpaRepository<Curation, Long> {
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -1,0 +1,16 @@
+package com.seb_main_004.whosbook.curation.service;
+
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.curation.repository.CurationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CurationService {
+    private final CurationRepository curationRepository;
+
+    public Curation createCuration(Curation curation){
+        return curationRepository.save(curation);
+    }
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/utils/UriCreator.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/utils/UriCreator.java
@@ -1,0 +1,14 @@
+package com.seb_main_004.whosbook.utils;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+public class UriCreator {
+    public static URI createUri(String uri, long id) {
+        return UriComponentsBuilder.newInstance()
+                .path(uri + "/" + id)
+                .build()
+                .toUri();
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -7,3 +7,4 @@ spring.jpa.database=mysql
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.format_sql=true
+spring.output.ansi.enabled=always


### PR DESCRIPTION
## 개요
- HTTP POST 메소드를 통해 `/curations` 호출시 질문 작성
- 회원과 연관관계 맵핑은 아직 안 되어있음

## 작업사항
- 질문 작성을 위한 컨트롤러, 서비스, 맵퍼, 리파지토리, DTO 코드 작성
- 모든 유효성 추가
- application.properties에 로그 색상 변경 설정 추가

### 참고사항
- 추후 Member 클래스와의 연관관계 맵핑 필요
- 추후 Category 클래스와의 연관관계 맵핑 필요

### 스크린샷
- gif, 이미지 파일 등

## 리뷰 요청사항
- 엔티티랑 DTO 관련해서 빠진 부분 없는지 한번 더 체크 부탁드립니다.