### PR TITLE
Feat/be-curationModify 큐레이션 수정 기본 기능 구현 (회원 제외)

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -1,5 +1,6 @@
 package com.seb_main_004.whosbook.curation.controller;
 
+import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
 import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import com.seb_main_004.whosbook.curation.mapper.CurationMapper;
@@ -13,6 +14,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 import java.net.URI;
 
 @RestController
@@ -35,5 +37,12 @@ public class CurationController {
         Curation savedCuration = curationService.createCuration(mapper.curationPostDtoToCuration(postDto));
         URI uri = UriCreator.createUri(CURATION_DEFAULT_URL, savedCuration.getCurationId());
         return ResponseEntity.created(uri).build();
+    }
+
+    @PatchMapping("/{curation-id}")
+    public ResponseEntity patchCuration(@RequestBody @Valid CurationPatchDto patchDto,
+                                        @PathVariable("curation-id") @Positive long curationId){
+        Curation updatedCuration = curationService.updateCuration(patchDto, curationId);
+        return new ResponseEntity(updatedCuration, HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -43,6 +43,7 @@ public class CurationController {
     public ResponseEntity patchCuration(@RequestBody @Valid CurationPatchDto patchDto,
                                         @PathVariable("curation-id") @Positive long curationId){
         Curation updatedCuration = curationService.updateCuration(patchDto, curationId);
-        return new ResponseEntity(updatedCuration, HttpStatus.OK);
+        URI uri = UriCreator.createUri(CURATION_DEFAULT_URL, updatedCuration.getCurationId());
+        return ResponseEntity.ok().header("Location", uri.getPath()).build();
     }
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
@@ -1,2 +1,26 @@
-package com.seb_main_004.whosbook.curation.dto;public class CurationPatchDto {
+package com.seb_main_004.whosbook.curation.dto;
+
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.vaildator.NotSpace;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Builder
+@Getter
+public class CurationPatchDto {
+    @NotBlank
+    @Length(max = 5)
+    private String emoji;
+    @NotBlank
+    @Length(min = 1, max = 30)
+    private String title;
+    @NotBlank
+    @Length(min = 10)
+    private String content;
+    @NotNull
+    private Curation.Visibility visibility;
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
@@ -1,0 +1,2 @@
+package com.seb_main_004.whosbook.curation.dto;public class CurationPatchDto {
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 @Data
 public class Curation {
 
+    //TODO : Member 엔티티와 연관관계 맵핑 필요
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long curationId;
     @Column(nullable = false, length = 5)

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -1,6 +1,7 @@
 package com.seb_main_004.whosbook.curation.entity;
 
 
+import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
 import lombok.Data;
 import lombok.Getter;
 
@@ -65,5 +66,12 @@ public class Curation {
         }
     }
 
+    public void updateCurationData(CurationPatchDto patchDto){
+        this.emoji = patchDto.getEmoji();
+        this.title = patchDto.getTitle();
+        this.content = patchDto.getContent();
+        this.visibility = patchDto.getVisibility();
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -24,7 +24,7 @@ public class Curation {
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
-    private Visibility visibilityStatus = Visibility.PUBLIC;
+    private Visibility visibility = Visibility.PUBLIC;
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -7,6 +7,6 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface CurationMapper {
-    @Mapping(source = "visibility", target = "visibilityStatus")
+
     Curation curationPostDtoToCuration(CurationPostDto postDto);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -30,15 +30,7 @@ public class CurationService {
             throw new BusinessLogicException(ExceptionCode.CURATION_HAS_BEEN_DELETED);
         }
 
-        Optional.ofNullable(patchDto.getEmoji())
-                .ifPresent(emoji -> findCuration.setEmoji(emoji));
-        Optional.ofNullable(patchDto.getTitle())
-                .ifPresent(title -> findCuration.setTitle(title));
-        Optional.ofNullable(patchDto.getContent())
-                .ifPresent(content -> findCuration.setContent(content));
-
-        findCuration.setVisibility(patchDto.getVisibility());
-        findCuration.setUpdatedAt(LocalDateTime.now());
+        findCuration.updateCurationData(patchDto);
 
         return curationRepository.save(findCuration);
     }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -1,9 +1,15 @@
 package com.seb_main_004.whosbook.curation.service;
 
+import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import com.seb_main_004.whosbook.curation.repository.CurationRepository;
+import com.seb_main_004.whosbook.exception.BusinessLogicException;
+import com.seb_main_004.whosbook.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,6 +17,36 @@ public class CurationService {
     private final CurationRepository curationRepository;
 
     public Curation createCuration(Curation curation){
+        //TODO : 로그인한 회원의 memberId를 curation에 주입 필요
         return curationRepository.save(curation);
+    }
+
+    public Curation updateCuration(CurationPatchDto patchDto, long curationId){
+        //TODO : 로그인한 회원과 작성자의 memberId가 일치하는지 확인 로직 필요
+
+        Curation findCuration = findVerifiedCurationById(curationId);
+
+        if(findCuration.getCurationStatus() == Curation.CurationStatus.CURATION_DELETE) {
+            throw new BusinessLogicException(ExceptionCode.CURATION_HAS_BEEN_DELETED);
+        }
+
+        Optional.ofNullable(patchDto.getEmoji())
+                .ifPresent(emoji -> findCuration.setEmoji(emoji));
+        Optional.ofNullable(patchDto.getTitle())
+                .ifPresent(title -> findCuration.setTitle(title));
+        Optional.ofNullable(patchDto.getContent())
+                .ifPresent(content -> findCuration.setContent(content));
+
+        findCuration.setVisibility(patchDto.getVisibility());
+        findCuration.setUpdatedAt(LocalDateTime.now());
+
+        return curationRepository.save(findCuration);
+    }
+
+    public Curation findVerifiedCurationById(long curationId) {
+        Optional<Curation> optionalCuration = curationRepository.findById(curationId);
+        return optionalCuration.orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.CURATION_NOT_FOUND)
+        );
     }
 }


### PR DESCRIPTION
## 개요
- 회원 기능을 제외한 큐레이션 수정 기능

## 작업사항
- 큐레이션 수정 기능을 위한 DTO, Service, Controller, Entity 클래스에 메소드 추가
- 삭제 된 글을 수정 할 시 비지니스 에러 추가
- 수정 완료시 헤더 `Location` key에 단일 상세 조회 uri 응답

### 참고사항
- 사용자가 기존 데이터를 토대로 수정하는 것이기에 변경된 필드만 찾기 어려워 모든 데이터를 수정하는 로직으로 구현
- 작성한 회원만 해당 큐레이션을 수정 할 수 있는 로직은 추후 추가 예정

### 스크린샷
![image](https://github.com/codestates-seb/seb44_main_004/assets/122109213/6c1faf16-625a-4e19-b197-031184a51123)

## 리뷰 요청사항
- 인가 관련 부분 제외하고 다른 부분에서 문제 없는지 확인 부탁드립니다.