### PR TITLE
feat: 큐레이션 작성 수정시 회원관련 기능 추가

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,7 +23,6 @@ import java.net.URI;
 @Slf4j
 @Validated
 @RequestMapping("/curations")
-
 public class CurationController {
     private final CurationService curationService;
     private final CurationMapper mapper;
@@ -34,16 +35,24 @@ public class CurationController {
 
     @PostMapping
     public ResponseEntity postCuration(@RequestBody @Valid CurationPostDto postDto){
-        Curation savedCuration = curationService.createCuration(mapper.curationPostDtoToCuration(postDto));
+
+        Curation savedCuration = curationService.createCuration(mapper.curationPostDtoToCuration(postDto), getAuthentication());
         URI uri = UriCreator.createUri(CURATION_DEFAULT_URL, savedCuration.getCurationId());
+
         return ResponseEntity.created(uri).build();
     }
 
     @PatchMapping("/{curation-id}")
     public ResponseEntity patchCuration(@RequestBody @Valid CurationPatchDto patchDto,
                                         @PathVariable("curation-id") @Positive long curationId){
-        Curation updatedCuration = curationService.updateCuration(patchDto, curationId);
+
+        Curation updatedCuration = curationService.updateCuration(patchDto, curationId, getAuthentication());
         URI uri = UriCreator.createUri(CURATION_DEFAULT_URL, updatedCuration.getCurationId());
+
         return ResponseEntity.ok().header("Location", uri.getPath()).build();
+    }
+
+    private Authentication getAuthentication(){
+        return SecurityContextHolder.getContext().getAuthentication();
     }
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
@@ -12,8 +12,7 @@ import javax.validation.constraints.Positive;
 @Builder
 @Getter
 public class CurationPostDto {
-    @Positive
-    private long memberId;
+
     @NotBlank
     @Length(max = 5)
     private String emoji;

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -2,6 +2,7 @@ package com.seb_main_004.whosbook.curation.entity;
 
 
 import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
+import com.seb_main_004.whosbook.member.entity.Member;
 import lombok.Data;
 import lombok.Getter;
 
@@ -32,6 +33,9 @@ public class Curation {
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private CurationStatus curationStatus = CurationStatus.CURATION_ACTIVE;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -34,13 +34,13 @@ public class CurationService {
     public Curation updateCuration(CurationPatchDto patchDto, long curationId, Authentication authentication){
 
         Curation findCuration = findVerifiedCurationById(curationId);
-        Member loginMember = memberService.findVerifiedMemberByEmail(authentication.getPrincipal().toString());
 
         if(findCuration.getCurationStatus() == Curation.CurationStatus.CURATION_DELETE) {
             throw new BusinessLogicException(ExceptionCode.CURATION_HAS_BEEN_DELETED);
         }
 
-        if(findCuration.getMember().getMemberId() != loginMember.getMemberId()) {
+        if(findCuration.getMember().getEmail()
+                .equals(authentication.getPrincipal().toString()) == false) {
             throw new BusinessLogicException(ExceptionCode.CURATION_CANNOT_CHANGE);
         }
 


### PR DESCRIPTION
## 개요
- 큐레이션 작성, 수정 시 회원과 관련된 기능 추가

## 작업사항
- Member, Curation 엔티티 연관관계 맵핑
- 질문 작성시 `SecurityContextHorder` 에서 `Authentication`의 `principal` 호출하여 사용자 이메일 검색
- 검색된 사용자를 작성되는 큐레이션에 넣어 저장
- 질문 수정시 위와 같은 방법으로 로그인한 사용자 이메일과 작성자 이메일이 동일한지 검증 후 수정

### 참고사항
- MemberService 클래스에 필요한 메소드가 있어서 동욱님께 요청드렸습니다. 그대로 머지 하게 되면 dev에서 pull 받아오면 에러가 발생 할 수 있으니 동욱님 PR이 먼저 머지되면 머지 하겠습니다.

### 스크린샷
- gif, 이미지 파일 등

## 리뷰 요청사항
- 보시고 궁금하시거나 보완이 필요한 부분 말씀해주세요.