### PR TITLE
Feat/fe-curationCard 큐레이션 카드 컴포넌트 레이아웃 구현

### DIFF
--- a/client/src/components/CurationCard.tsx
+++ b/client/src/components/CurationCard.tsx
@@ -1,0 +1,87 @@
+import tw from "twin.macro";
+import styled from "styled-components";
+import {AiFillHeart, AiOutlineHeart}from "react-icons/ai";
+
+interface CurationProps {
+    emoji?: string,
+    title?: string,
+    content?: string,
+    likes?: number,
+    nickname?: string,
+    memberId?: string,
+}
+const CurationCard = ({emoji, title, content, likes, nickname, memberId}:CurationProps) => {
+
+    //클릭시 
+    return(
+        <CardContainer>
+            <Item>{emoji}</Item>
+            <Item>{title}</Item>
+            <Item>{content}</Item>
+            <Item>
+                <div className="likes">
+                    🖤 좋아요 {likes}개
+                </div>
+                <div className="nickname">
+                    {nickname}
+                </div>
+            </Item>
+          
+               
+        </CardContainer>
+    )
+
+}
+const CardContainer = styled.div`
+    width: calc(33.33%);
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1.5rem 2rem ;
+    margin: 1rem;
+    font-size: 1.2vw;
+    border-radius: 0.625rem;
+    background-color: #D9E1E8;
+    box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+    cursor: pointer;
+    
+    &:hover{
+        background-color: ${({theme}) => theme.colors.mainPastelBlue300};
+        color: white;
+        >div:nth-child(3){
+            color: white;
+        }
+    }
+`;
+const Item = styled.div`
+    margin: 0.5rem 0;
+    &:first-child {
+        font-size: 2vw;
+    }
+    &:nth-child(2){
+        font-size: 1.4vw;
+        font-weight: 600;
+    }
+    &:nth-child(3){
+        overflow: hidden;
+        white-space: normal;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        color: #595656;
+    }
+    &:last-child{
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        margin-top: 1rem;
+        
+    }
+    > .nickname{
+        font-weight: 400;
+    }
+
+`
+export default CurationCard;

--- a/client/src/components/CurationCard.tsx
+++ b/client/src/components/CurationCard.tsx
@@ -20,7 +20,8 @@ const CurationCard = ({emoji, title, content, likes, nickname, memberId}:Curatio
             <Item>{content}</Item>
             <Item>
                 <div className="likes">
-                    🖤 좋아요 {likes}개
+                    <AiFillHeart size="1.5rem"/>
+                    좋아요 {likes}개
                 </div>
                 <div className="nickname">
                     {nickname}
@@ -56,6 +57,7 @@ const CardContainer = styled.div`
 `;
 const Item = styled.div`
     margin: 0.5rem 0;
+    
     &:first-child {
         font-size: 2vw;
     }
@@ -72,6 +74,18 @@ const Item = styled.div`
         -webkit-box-orient: vertical;
         color: #595656;
     }
+    &:nth-child(4){
+        display: flex;
+        align-items: center;
+        > .likes{
+            display: flex;
+            align-items: center;
+            gap: 0.3rem;
+        }
+        > .nickname{
+            font-weight: 400;
+        }
+    }
     &:last-child{
         width: 100%;
         display: flex;
@@ -79,9 +93,7 @@ const Item = styled.div`
         margin-top: 1rem;
         
     }
-    > .nickname{
-        font-weight: 400;
-    }
+   
 
 `
 export default CurationCard;

--- a/client/src/components/SubCuratorCard.tsx
+++ b/client/src/components/SubCuratorCard.tsx
@@ -1,0 +1,90 @@
+import tw from "twin.macro";
+import styled from "styled-components";
+
+import {BsPersonCircle} from "react-icons/bs"
+import {RxDividerVertical} from "react-icons/rx";
+
+const SubCuratorCard = () => {
+
+    return(
+        <CuratorContainer>
+            <CuratorLeft>
+               
+                    <BsPersonCircle size="3rem"/>
+            </CuratorLeft>
+                
+            <CuratorRight>
+               <CuratorInfo>
+                   
+                    <UserNickname>
+                        앙꼬
+                    </UserNickname>
+                    <UserInfo>
+                        구독자 10명
+                    </UserInfo>
+                    <RxDividerVertical size="1.2rem"/>
+                    <UserInfo>
+                        작성한 큐레이션 5개
+                    </UserInfo>
+                    
+                </CuratorInfo>
+               <CuratorIntro>
+                    안녕하세요. 앙꼬 입니다. 팥앙꼬를 좋아합니다.
+                    안녕하세요. 앙꼬 입니다. 팥앙꼬를 좋아합니다.
+                </CuratorIntro>
+                
+            </CuratorRight>
+        </CuratorContainer>
+    )
+}
+
+const CuratorContainer = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 1.3rem 2rem ;
+    margin: 1rem;
+    
+    font-size: 1.2vw;
+    border-radius: 0.625rem;
+    background-color: #D9E1E8;
+    box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+    cursor: pointer;
+
+    &:hover{
+        background-color: ${({theme}) => theme.colors.mainPastelBlue300};
+        color: white;
+    }   
+    svg{
+        display:flex;
+        align-items: center;
+    }
+
+`;
+const CuratorLeft = tw.div`
+    mr-8
+`;
+const CuratorRight = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    >div:last-child{
+        margin-right: auto;
+    }
+`;
+const CuratorInfo = tw.div`
+    flex
+    items-center
+    gap-2
+`;
+const UserNickname = tw.p`
+    text-lg
+`;
+const UserInfo = tw.p`
+    
+`;
+const CuratorIntro = tw.div`
+    
+`;
+
+export default SubCuratorCard;


### PR DESCRIPTION
## 개요
- 큐레이션 카드, 마이페이지에서 쓰이는 큐레이터 카드 레이아웃 구현

</br>

## 작업사항
- 큐레이션 카드, 큐레이터 카드 레이아웃, css 적용(hover 포함)

</br>

## 참고사항
- 큐레이션 카드 ```CurationCard.tsx``` 
  -  부모 컴포넌트로부터 ```emoji```, ```title```, ```content```, ```likes```, ```nickname``` 을 받아오는 것으로 설정
  - 마이페이지에서는 가로로 두 개씩, 나머지 페이지에서는 가로로 세 개씩 렌더링 되는 부분이라 width 적용은 추후 할 계획 
- 큐레이터 카드 ```SubCuratior.tsx``` 
  - 추후 props 설정 할 계획
  - 프로필 이미지 부분은 이미지가 존재할 경우에는 이미지로 대체되며, 그렇지 않을 경우 기본 React-icons 로 보여집니다.

</br>

## 스크린샷

1.  큐레이션 카드
<img width="496" alt="스크린샷 2023-07-06 오전 9 54 17" src="https://github.com/codestates-seb/seb44_main_004/assets/76391160/37cad73c-1f4d-43fc-82ff-c30e8976311b" >

2. 큐레이터 카드
<img width="1420" alt="스크린샷 2023-07-06 오전 9 54 28" src="https://github.com/codestates-seb/seb44_main_004/assets/76391160/336a9046-0d45-4284-a1d5-0620c79b7732">

</br>

## 리뷰 요청사항

- 스크린샷 보시고 혹시나 수정할 부분이 있으면 조언 부탁드립니다.