### PR TITLE
[BE] 멤버도메인 CRUD(인증기능 미포함)

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 public enum ExceptionCode {
     MEMBER_NOT_FOUND(404,"사용자를 찾을 수 없습니다."),
     MEMBER_EXISTS(409,"사용자가 이미 존재 합니다."),
+    NICKNAME_EXISTS(409,"닉네임이 이미 존재 합니다."),
     MEMBER_NO_HAVE_AUTHORIZATION(401,"인증되지 않은 사용자입니다."),
     MEMBER_NOT_VALID(409, "등록되지 않은 사용자입니다."),
     MEMBER_DOES_NOT_MATCH(403,"사용자가 맞지 않습니다."),

--- a/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
@@ -1,19 +1,21 @@
 package com.seb_main_004.whosbook.member.controller;
 
+import com.seb_main_004.whosbook.member.dto.MemberPatchDto;
 import com.seb_main_004.whosbook.member.dto.MemberPostDto;
+import com.seb_main_004.whosbook.member.dto.MultiResponseDto;
 import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.mapper.MemberMapper;
 import com.seb_main_004.whosbook.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import java.util.List;
 
 @RestController
 @RequestMapping("/members")
@@ -36,4 +38,44 @@ public class MemberController {
 
         return new ResponseEntity(memberMapper.memberToMemberResponseDto(response), HttpStatus.CREATED);
     }
+
+    @PatchMapping("/{member-id}")
+    public ResponseEntity patchMember(@Positive @PathVariable("member-id") @Positive long memberId,
+                                      @Valid @RequestBody MemberPatchDto memberPatchDto) {
+        memberPatchDto.setMemberId(memberId);
+
+        Member member = memberMapper.memberPatchDtoToMember(memberPatchDto);
+
+        Member response = memberService.updateMember(member);
+
+        return new ResponseEntity(memberMapper.memberToMemberResponseDto(response), HttpStatus.OK);
+    }
+
+    @GetMapping("/{member-id}")
+    public ResponseEntity getMember(@Positive @PathVariable("member-id") @Positive long memberId) {
+        Member response = memberService.findMember(memberId);
+
+        return new ResponseEntity(memberMapper.memberToMemberResponseDto(response), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity getMembers(@Positive @RequestParam("page") int page,
+                                     @Positive @RequestParam("size") int size) {
+        Page<Member> pageMember = memberService.findMembers(page-1, size);
+        List<Member> members = pageMember.getContent();
+
+        return new ResponseEntity(
+                new MultiResponseDto(memberMapper.membersToMemberResponseDtos(members),
+                        pageMember), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{member-id}")
+    public ResponseEntity deleteMember(@PathVariable("member-id") @Positive long memberId) {
+        
+        memberService.deleteMember(memberId);
+
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+
+
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberPatchDto.java
@@ -1,0 +1,24 @@
+package com.seb_main_004.whosbook.member.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
+
+@Data
+public class MemberPatchDto {
+    @Positive
+    private long memberId;
+
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,15}$", message = "닉네임은 2글자 이상 15글자 미만의 영어, 한글, 숫자로 이루어져야 합니다.")
+    private String nickname;
+
+    @Size(min = 1, max = 200, message = "텍스트는 최대 200자까지 입력 가능합니다.")
+    private String introduction;
+
+//    패스워드, 이미지 수정은 논의 후 구현예정
+//    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$", message = "비밀번호는 영문, 숫자, 특수문자(!@#$%^&*)를 포함한 8자 이상이어야 합니다.")
+//    private String password;
+//    private String image;
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberPostDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberPostDto.java
@@ -9,8 +9,6 @@ import javax.validation.constraints.Positive;
 
 @Data
 public class MemberPostDto {
-    @Positive
-    private long memberId;
 
     @NotBlank(message = "이메일을 입력해주세요.")
     @Email(message = "유효한 이메일 주소를 입력해주세요.")

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberResponseDto.java
@@ -12,6 +12,8 @@ public class MemberResponseDto {
 
     private String nickname;
 
+    private String introduction;
+
 //    회원가입 시 이미지 업로드를 위한 변수로서, 추후 구현
 //    private String image;
 

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/MultiResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/MultiResponseDto.java
@@ -1,0 +1,19 @@
+package com.seb_main_004.whosbook.member.dto;
+
+import com.seb_main_004.whosbook.dto.PageInfo;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class MultiResponseDto<T> {
+    private List<T> data;
+    private PageInfo pageInfo;
+
+    public MultiResponseDto(List<T> data, Page page) {
+        this.data = data;
+        this.pageInfo = new PageInfo(page.getNumber() + 1,
+                page.getSize(), page.getTotalElements(), page.getTotalPages());
+    }
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/member/entity/Member.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/entity/Member.java
@@ -26,6 +26,9 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
+    private String introduction;
+
+
 //    회원가입 시 이미지 업로드를 위한 변수로서, 추후 구현
 //    private String image;
 

--- a/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapper.java
@@ -1,15 +1,21 @@
 package com.seb_main_004.whosbook.member.mapper;
 
+import com.seb_main_004.whosbook.member.dto.MemberPatchDto;
 import com.seb_main_004.whosbook.member.dto.MemberPostDto;
 import com.seb_main_004.whosbook.member.dto.MemberResponseDto;
 import com.seb_main_004.whosbook.member.entity.Member;
 import org.mapstruct.Mapper;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
-    //memberPostDtoToMember
-    //memberToMemberResponseDto
+
     Member memberPostDtoToMember(MemberPostDto memberPostDto);
+
+    Member memberPatchDtoToMember(MemberPatchDto memberPatchDto);
+
+    List<MemberResponseDto> membersToMemberResponseDtos(List<Member> members);
 
     MemberResponseDto memberToMemberResponseDto(Member member);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/repository/MemberRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
@@ -1,13 +1,19 @@
 package com.seb_main_004.whosbook.member.service;
 
 import com.seb_main_004.whosbook.auth.utils.CustomAuthorityUtils;
+import com.seb_main_004.whosbook.exception.BusinessLogicException;
+import com.seb_main_004.whosbook.exception.ExceptionCode;
 import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.repository.MemberRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,8 +32,14 @@ public class MemberService {
     }
 
     public Member createMember(Member member) {
-        Optional<Member> optionalMember = memberRepository.findByEmail(member.getEmail());
+        Optional<Member> optionalMemberEmail = memberRepository.findByEmail(member.getEmail());
+        Optional<Member> optionalMemberNickName = memberRepository.findByNickname(member.getNickname());
 
+        if(optionalMemberEmail.isPresent())
+            throw new BusinessLogicException(ExceptionCode.MEMBER_EXISTS);
+
+        if(optionalMemberNickName.isPresent())
+            throw new BusinessLogicException(ExceptionCode.NICKNAME_EXISTS);
         //password 암호화
         String encryptedPassword= passwordEncoder.encode(member.getPassword());
         member.setPassword(encryptedPassword);
@@ -36,12 +48,53 @@ public class MemberService {
         List<String> roles= authorityUtils.createRoles(member.getEmail());
         member.setRoles(roles);
 
-        if(optionalMember.isPresent())
-            throw new ResponseStatusException(HttpStatus.CONFLICT); // 추후 비즈니스로직으로 수정필요
-
         return memberRepository.save(member);
-
     }
 
+    public Member updateMember(Member member) {
+        Member findMember = findVerifiedMember(member.getMemberId());
+
+        Optional.ofNullable(member.getNickname())
+                .ifPresent(nickname->findMember.setNickname(nickname));
+        Optional.ofNullable(member.getIntroduction())
+                .ifPresent(introduction->findMember.setIntroduction(introduction));
+
+        findMember.setUpdatedAt(LocalDateTime.now());
+
+        return memberRepository.save(findMember);
+    }
+
+    public Member findMember(long memberId) {
+        Member findMember = findVerifiedMember(memberId);
+
+        return findMember;
+    }
+
+    public Page<Member> findMembers(int page, int size) {
+        return memberRepository.findAll(PageRequest.of(page, size,
+                Sort.by("memberId").descending()));
+    }
+
+    public void deleteMember(long memberId) {
+        Member findMember = findVerifiedMember(memberId);
+
+        memberRepository.delete(findMember);
+    }
+
+    public Member findVerifiedMember(long memberId) throws BusinessLogicException {
+        Optional<Member> optionalMember =
+                memberRepository.findById(memberId);
+        Member findMember =
+                optionalMember.orElseThrow(()-> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+
+        return findMember;
+    }
+
+    public Member findVerifiedMemberByEmail(String email){
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+        return optionalMember.orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND)
+        );
+    }
 
 }


### PR DESCRIPTION
## 개요
- 멤버 도메인 CRUD 구현

## 작업사항
- 멤버 도메인 CRUD 구현

### 참고사항
- memberPostDto에서 memberId 변수 제거
- member도메인 변수에 'introduction(자기소개)' 추가
 -> 자기소개는 회원가입 후 마이페이지에서 최초작성 및 수정이 가능한 것으로 상정
- memberService에 회원 이메일 검증 메소드 추가
- get과 gets는 추후 연관관계 매핑 후 큰 폭으로 수정될 것으로 예상

** 현재 인증기능과의 연동은 없는 기본CRUD 입니다. 추후 연동할 예정입니다.  

## 리뷰 요청사항
- 참고사항의 예외 처리 이외에 추가로 예외 처리가 필요한 부분이 있을 지 조언 부탁드립니다.