### PR TITLE
큐레이션 수정 페이지 레이아웃 작업 완료

### DIFF
--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -16,6 +16,7 @@ const QuillEditor = memo(({ quillRef, curationContent, setcurationContent }: Qui
           ["bold", "italic", "underline", "strike", "blockquote"],
           [{ size: ["small", false, "large", "huge"] }, { color: [] }],
           ['code-block'],
+          ['link', 'image'],
           [{ list: "ordered" }, { list: "bullet" }, { indent: "-1" }, { indent: "+1" }, { align: [] }],
         ],
       },

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -13,7 +13,7 @@ const QuillEditor = memo(({ quillRef, curationContent, setcurationContent }: Qui
     () => ({
       toolbar: {
         container: [
-          [{ header: [1, 2, false] }],
+          [{ header: [1, 2] }],
           ["bold", "italic", "underline", "strike", "blockquote"],
           [
             { list: "ordered" },
@@ -42,11 +42,12 @@ const QuillEditor = memo(({ quillRef, curationContent, setcurationContent }: Qui
       theme= "bubble"
       placeholder="큐레이션의 내용을 입력해 주세요"
       style={{
+        fontWeight: "100",
         marginBottom: '0.3rem',
         backgroundColor: '#f8f7f7',
         border: 'none',
         borderRadius: '0.3rem',
-        height: '200px',
+        height: '18.75rem',
       }}
     />
   );

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -1,0 +1,49 @@
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.bubble.css';
+import { MutableRefObject, memo, useMemo } from 'react';
+
+type QuillEditorProps = {
+  quillRef: MutableRefObject<unknown>;
+  curationContent: string;
+  setcurationContent: (content: string) => void;
+};
+
+const QuillEditor = memo(({ quillRef, curationContent, setcurationContent }: QuillEditorProps) => {
+  const modules = useMemo(
+    () => ({
+      toolbar: {
+        container: [
+          ["bold", "italic", "underline", "strike", "blockquote"],
+          [{ size: ["small", false, "large", "huge"] }, { color: [] }],
+          ['code-block'],
+          [{ list: "ordered" }, { list: "bullet" }, { indent: "-1" }, { indent: "+1" }, { align: [] }],
+        ],
+      },
+    }),
+    []
+  );
+
+  return (
+    <ReactQuill
+      ref={(element) => {
+        if (element !== null) {
+          quillRef.current = element.getEditor();
+        }
+      }}
+      value={curationContent}
+      onChange={setcurationContent}
+      modules={modules}
+      theme= "bubble"
+      placeholder="큐레이션의 내용을 입력해 주세요"
+      style={{
+        marginBottom: '0.3rem',
+        backgroundColor: '#fff',
+        border: 'none',
+        borderRadius: '0.3rem',
+        height: '100px',
+      }}
+    />
+  );
+});
+
+export default QuillEditor;

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -13,11 +13,15 @@ const QuillEditor = memo(({ quillRef, curationContent, setcurationContent }: Qui
     () => ({
       toolbar: {
         container: [
+          [{ header: [1, 2, false] }],
           ["bold", "italic", "underline", "strike", "blockquote"],
-          [{ size: ["small", false, "large", "huge"] }, { color: [] }],
-          ['code-block'],
-          ['link', 'image'],
-          [{ list: "ordered" }, { list: "bullet" }, { indent: "-1" }, { indent: "+1" }, { align: [] }],
+          [
+            { list: "ordered" },
+            { list: "bullet" },
+            { indent: "-1" },
+            { indent: "+1" },
+          ],
+          ["link"],
         ],
       },
     }),
@@ -38,10 +42,10 @@ const QuillEditor = memo(({ quillRef, curationContent, setcurationContent }: Qui
       placeholder="큐레이션의 내용을 입력해 주세요"
       style={{
         marginBottom: '0.3rem',
-        backgroundColor: '#fff',
+        backgroundColor: '#f8f7f7',
         border: 'none',
         borderRadius: '0.3rem',
-        height: '100px',
+        height: '200px',
       }}
     />
   );

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -22,6 +22,7 @@ const QuillEditor = memo(({ quillRef, curationContent, setcurationContent }: Qui
             { indent: "+1" },
           ],
           ["link"],
+          ["image"],
         ],
       },
     }),

--- a/client/src/pages/CurationEditPage.tsx
+++ b/client/src/pages/CurationEditPage.tsx
@@ -189,7 +189,7 @@ const SearchInputButton = styled.label`
   font-size: .8rem;
   font-weight: 100;
   &:hover {
-    background-color: #f8f7f7;
+    background-color: #e1e1e1;
   }
 `;
 

--- a/client/src/pages/CurationEditPage.tsx
+++ b/client/src/pages/CurationEditPage.tsx
@@ -1,0 +1,190 @@
+import styled from "styled-components";
+import { useState, useRef } from 'react';
+import QuillEditor from '../components/quill/QuillEditor';
+
+const CurationWritePage = () => {
+  const [curationContent, setCurationContent] = useState("");
+  const quillRef = useRef(null);
+
+  return (
+    <Container>
+      <MainTitle>큐레이션 수정하기</MainTitle>
+      <FormContainer>
+        <Form>
+          <FormLabel>제목</FormLabel>
+          <FormInput placeholder="큐레이션의 제목을 입력해 주세요" />
+        </Form>
+        <Form>
+          <FormLabel>이모지</FormLabel>
+          <FormInput placeholder="큐레이션에 어울리는 이모지를 선택해 주세요" />
+        </Form>
+        <Form>
+            <FormLabel>내용</FormLabel>
+              <QuillEditor quillRef={quillRef} curationContent={curationContent} setcurationContent={setCurationContent} />
+        </Form>
+        <Form>
+          <FormLabel>카테고리</FormLabel>
+          <FormInput placeholder="추천하는 책의 카테고리를 입력해 주세요" />
+        </Form>
+        <Form>
+          <FormLabel>책 정보 등록</FormLabel>
+          <FormInput placeholder="추천하는 책을 검색 후 등록해 주세요" />
+        </Form>
+        <Form>
+          <FormLabel>이미지 첨부</FormLabel>
+          <FileInputContainer>
+            <FileInput
+              type="file"
+              accept="image/jpg, image/png, image/jpeg"
+              id="fileInput"
+            />
+            <FileInputLabel htmlFor="fileInput">이미지를 찾아 업로드 해주세요</FileInputLabel>
+            <FileInputButton htmlFor="fileInput">이미지 찾기</FileInputButton>
+          </FileInputContainer>
+        </Form>
+        <ButtonContainer>
+          <Button variant="secret">비공개로 발행</Button>
+          <Button variant="cancel">취소</Button>
+          <Button variant="create">발행</Button>
+        </ButtonContainer>
+      </FormContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const MainTitle = styled.div`
+  margin: 4rem 0rem 3rem 0rem;
+  text-align: center;
+  font-size: 3rem;
+  font-weight: 700;
+`;
+
+const FormContainer = styled.div`
+  background-color: #f8f7f7;
+  border-radius: 0.3rem;
+  padding: 3rem;
+  width: 40rem;
+  margin-bottom: 8rem;
+`;
+
+const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+`;
+
+const FormLabel = styled.label`
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+`;
+
+const FormTextArea = styled.textarea`
+  width: 100%;
+  padding: 0.7rem;
+  height: 9rem;
+  font-weight: 100;
+  border: 0.06rem solid #ffffff;
+  border-radius: 0.3rem;
+`;
+
+const FormInput = styled.textarea`
+  width: 100%;
+  padding: 0.7rem;
+  height: 2.5rem;
+  font-weight: 100;
+  border: 0.06rem solid #ffffff;
+  border-radius: 0.3rem;
+`;
+
+const FileInputContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const FileInput = styled.input`
+  width: 100%;
+  padding: 0.7rem;
+  height: 2.5rem;
+  border: 1px solid #ffffff;
+  background-color: #ffffff;
+  border-radius: 0.3rem;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+const FileInputLabel = styled.label`
+  cursor: pointer;
+  width: 80%;
+  display: block;
+  padding: 0.6rem;
+  border: 1px solid #ffffff;
+  background-color: #ffffff;
+  border-radius: 0.3rem;
+  color: #757575;
+  font-size: 13px;
+  font-weight: 100;
+`;
+
+const FileInputButton = styled.label`
+  cursor: pointer;
+  width: 18%;
+  display: block;
+  padding: 0.6rem;
+  text-align: center;
+  border: 1px solid #f8f7f7;
+  background-color:  #dbdbdb;
+  border-radius: 0.3rem;
+  color: #757575;
+  font-size: 13px;
+  font-weight: 100;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 3rem;
+`;
+
+const Button = styled.div<{ variant: string }>`
+  padding: 0.6rem;
+  background-color: #ffffff;
+  color: #3173f6;
+  border-color: #3173f6;
+  border: 0.1rem solid;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  font-weight: 500;
+
+  ${({ variant }) => {
+    if (variant === "secret") {
+      return `
+        color: #3173f6;
+        border-color: #3173f6;
+        margin-right: 19.4rem;
+      `;
+    } else if (variant === "cancel") {
+      return `
+        color: #fd8f8f;
+        border-color: #fd8f8f;
+        margin-right: 1rem;
+      `;
+    } else if (variant === "create") {
+      return `
+        color: #3173f6;
+        border-color: #3173f6;
+      `;
+    }
+  }}
+`;
+
+export default CurationWritePage;

--- a/client/src/pages/CurationEditPage.tsx
+++ b/client/src/pages/CurationEditPage.tsx
@@ -1,54 +1,82 @@
+import { useState, useRef, ChangeEvent } from 'react';
+import tw from 'twin.macro';
 import styled from "styled-components";
-import { useState, useRef } from 'react';
+
 import QuillEditor from '../components/quill/QuillEditor';
+import Input from '../components/input/Input';
+import Label from '../components/label/Label';
+import Button from '../components/buttons/Button';
 
 const CurationWritePage = () => {
-  const [curationContent, setCurationContent] = useState("");
+  const [curationContent, setCurationContent] = useState('');
+  const [inputValue, setInputValue] = useState('');
   const quillRef = useRef(null);
 
   return (
+    <><TitleContainer>큐레이션 수정하기</TitleContainer>
     <Container>
-      <MainTitle>큐레이션 수정하기</MainTitle>
       <FormContainer>
-        <Form>
-          <FormLabel>제목</FormLabel>
-          <FormInput placeholder="큐레이션의 제목을 입력해 주세요" />
-        </Form>
-        <Form>
-          <FormLabel>이모지</FormLabel>
-          <FormInput placeholder="큐레이션에 어울리는 이모지를 선택해 주세요" />
-        </Form>
-        <Form>
-            <FormLabel>내용</FormLabel>
-              <QuillEditor quillRef={quillRef} curationContent={curationContent} setcurationContent={setCurationContent} />
-        </Form>
-        <Form>
-          <FormLabel>카테고리</FormLabel>
-          <FormInput placeholder="추천하는 책의 카테고리를 입력해 주세요" />
-        </Form>
-        <Form>
-          <FormLabel>책 정보 등록</FormLabel>
-          <FormInput placeholder="추천하는 책을 검색 후 등록해 주세요" />
-        </Form>
-        <Form>
-          <FormLabel>이미지 첨부</FormLabel>
-          <FileInputContainer>
-            <FileInput
-              type="file"
-              accept="image/jpg, image/png, image/jpeg"
-              id="fileInput"
-            />
-            <FileInputLabel htmlFor="fileInput">이미지를 찾아 업로드 해주세요</FileInputLabel>
-            <FileInputButton htmlFor="fileInput">이미지 찾기</FileInputButton>
-          </FileInputContainer>
-        </Form>
+        <ItemContainer>
+          <Label type="title" htmlFor="title" content="제목" />
+          <Input
+            id="title"
+            placeholder="큐레이션의 제목을 입력해 주세요"
+            width="100%"
+            color="#000"
+            value={inputValue}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setInputValue(e.target.value)} />
+        </ItemContainer>
+        <ItemContainer>
+          <Label type="title" htmlFor="title" content="이모지" />
+          <Input
+            id="emoji"
+            placeholder="큐레이션에 어울리는 이모지를 선택해 주세요"
+            width="100%"
+            color="#000"
+            value={inputValue}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setInputValue(e.target.value)} />
+        </ItemContainer>
+        <ItemContainer>
+          <Label type="title" htmlFor="title" content="내용" />
+          <Label type="content" htmlFor="content" content="마우스 드래그로 영역을 선택하면 서식을 수정하고, 이미지도 넣을 수 있어요!" />
+          <QuillEditor quillRef={quillRef} curationContent={curationContent} setcurationContent={setCurationContent} />
+        </ItemContainer>
+        <ItemContainer>
+          <Label type="title" htmlFor="title" content="카테고리 선택" />
+          <select id="countries">
+            <option selected>추천하는 책의 카테고리를 선택해 주세요</option>
+            <option value="자기계발">자기계발</option>
+            <option value="경영/경제">경영/경제</option>
+            <option value="가정/육아">가정/육아</option>
+            <option value="수험서">수험서</option>
+          </select>
+        </ItemContainer>
+        <ItemContainer>
+          <Label type="title" htmlFor="title" content="책 정보 등록" />
+          <SearchInputContainer>
+            <SearchInputLabel>추천하는 책을 검색 후 등록해 주세요</SearchInputLabel>
+            <SearchInputButton>책 검색하기</SearchInputButton>
+          </SearchInputContainer>
+        </ItemContainer>
+        <ItemContainer>
+        <Label type="title" htmlFor="title" content="큐레이션 공개 여부" />
+          <RadioButtonContainer>
+            <input type="radio" id="select" name="radio"/>
+            <label htmlFor="select">공개</label>
+            <input type="radio" id="select2" name="radio"/>
+            <label htmlFor="select2">비공개</label>
+          </RadioButtonContainer>
+        </ItemContainer>
         <ButtonContainer>
-          <Button variant="secret">비공개로 발행</Button>
-          <Button variant="cancel">취소</Button>
-          <Button variant="create">발행</Button>
+          <CancelButton>
+            <Button type="cancel" content="취소" />
+          </CancelButton>
+          <PrimaryButton>
+            <Button type="primary" content="발행" />
+          </PrimaryButton>
         </ButtonContainer>
       </FormContainer>
-    </Container>
+    </Container></>
   );
 };
 
@@ -59,70 +87,38 @@ const Container = styled.div`
   justify-content: center;
 `;
 
-const MainTitle = styled.div`
+const FormContainer = styled.div`
+  background-color: #EFEFEF;
+  border-radius: 0.3rem;
+  padding: 0rem 3rem 2rem 3rem;
+  width: 40rem;
+  margin-bottom: 8rem;
+`;
+
+const TitleContainer = styled.div`
   margin: 4rem 0rem 3rem 0rem;
   text-align: center;
   font-size: 3rem;
   font-weight: 700;
 `;
 
-const FormContainer = styled.div`
-  background-color: #f8f7f7;
-  border-radius: 0.3rem;
-  padding: 3rem;
-  width: 40rem;
-  margin-bottom: 8rem;
+const ItemContainer = tw.div`
+  bg-inherit
+  flex
+  flex-col
+  mt-12
+  w-full
+  [> label]:mb-3
+  [> button]:mb-3
 `;
 
-const Form = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 2rem;
-`;
-
-const FormLabel = styled.label`
-  font-weight: 500;
-  margin-bottom: 0.5rem;
-`;
-
-const FormTextArea = styled.textarea`
-  width: 100%;
-  padding: 0.7rem;
-  height: 9rem;
-  font-weight: 100;
-  border: 0.06rem solid #ffffff;
-  border-radius: 0.3rem;
-`;
-
-const FormInput = styled.textarea`
-  width: 100%;
-  padding: 0.7rem;
-  height: 2.5rem;
-  font-weight: 100;
-  border: 0.06rem solid #ffffff;
-  border-radius: 0.3rem;
-`;
-
-const FileInputContainer = styled.div`
+const SearchInputContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
 `;
 
-const FileInput = styled.input`
-  width: 100%;
-  padding: 0.7rem;
-  height: 2.5rem;
-  border: 1px solid #ffffff;
-  background-color: #ffffff;
-  border-radius: 0.3rem;
-  opacity: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
-`;
-
-const FileInputLabel = styled.label`
+const SearchInputLabel = styled.label`
   cursor: pointer;
   width: 80%;
   display: block;
@@ -135,7 +131,7 @@ const FileInputLabel = styled.label`
   font-weight: 100;
 `;
 
-const FileInputButton = styled.label`
+const SearchInputButton = styled.label`
   cursor: pointer;
   width: 18%;
   display: block;
@@ -152,39 +148,21 @@ const FileInputButton = styled.label`
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
-  margin-top: 3rem;
 `;
 
-const Button = styled.div<{ variant: string }>`
-  padding: 0.6rem;
-  background-color: #ffffff;
-  color: #3173f6;
-  border-color: #3173f6;
-  border: 0.1rem solid;
-  border-radius: 0.3rem;
-  cursor: pointer;
-  font-weight: 500;
+const CancelButton = styled.div`
+  margin: 10px;
+`;
 
-  ${({ variant }) => {
-    if (variant === "secret") {
-      return `
-        color: #3173f6;
-        border-color: #3173f6;
-        margin-right: 19.4rem;
-      `;
-    } else if (variant === "cancel") {
-      return `
-        color: #fd8f8f;
-        border-color: #fd8f8f;
-        margin-right: 1rem;
-      `;
-    } else if (variant === "create") {
-      return `
-        color: #3173f6;
-        border-color: #3173f6;
-      `;
-    }
-  }}
+const PrimaryButton = styled.div`
+  margin: 10px;
+`;
+
+const RadioButtonContainer = styled.div`
+  margin: 0rem 3rem 3rem -0.3rem;
+  cursor: pointer;
+  font-size: 15px;
+  color: #757575;
 `;
 
 export default CurationWritePage;

--- a/client/src/pages/CurationEditPage.tsx
+++ b/client/src/pages/CurationEditPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, ChangeEvent } from 'react';
+import { useState, useRef, ChangeEvent, MouseEventHandler } from 'react';
 import tw from 'twin.macro';
 import styled from "styled-components";
 
@@ -7,76 +7,121 @@ import Input from '../components/input/Input';
 import Label from '../components/label/Label';
 import Button from '../components/buttons/Button';
 
+interface OptionData {
+  value: string;
+  key: string;
+}
+
 const CurationWritePage = () => {
   const [curationContent, setCurationContent] = useState('');
-  const [inputValue, setInputValue] = useState('');
+  const [emojiValue, setEmojiValue] = useState('');
+  const [titleValue, setTitleValue] = useState('');
   const quillRef = useRef(null);
 
+  const CustomSelect = ({ optionData }: { optionData: OptionData[] }) => {
+    const [currentValue, setCurrentValue] = useState(optionData[0].value);
+    const [showOptions, setShowOptions] = useState(false);
+  
+    const handleOnChangeSelectValue: MouseEventHandler<HTMLLIElement> = (e) => {
+      setCurrentValue(e.currentTarget.getAttribute("value") || "");
+    };
+
+    return (
+      <SelectBox onClick={() => setShowOptions((prev) => !prev)}>
+        <CategoryLabel>{currentValue}</CategoryLabel>
+        <SelectOptions show={showOptions}>
+          {optionData.map((data: OptionData) => (
+            <Option
+              key={data.key}
+              value={data.value}
+              onClick={handleOnChangeSelectValue}
+            >
+              {data.value}
+            </Option>
+          ))}
+        </SelectOptions>
+      </SelectBox>
+    );
+  };
+
   return (
-    <><TitleContainer>큐레이션 수정하기</TitleContainer>
-    <Container>
-      <FormContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="title" content="제목" />
-          <Input
-            id="title"
-            placeholder="큐레이션의 제목을 입력해 주세요"
-            width="100%"
-            color="#000"
-            value={inputValue}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setInputValue(e.target.value)} />
-        </ItemContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="title" content="이모지" />
-          <Input
-            id="emoji"
-            placeholder="큐레이션에 어울리는 이모지를 선택해 주세요"
-            width="100%"
-            color="#000"
-            value={inputValue}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setInputValue(e.target.value)} />
-        </ItemContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="title" content="내용" />
-          <Label type="content" htmlFor="content" content="마우스 드래그로 영역을 선택하면 서식을 수정하고, 이미지도 넣을 수 있어요!" />
-          <QuillEditor quillRef={quillRef} curationContent={curationContent} setcurationContent={setCurationContent} />
-        </ItemContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="title" content="카테고리 선택" />
-          <select id="countries">
-            <option selected>추천하는 책의 카테고리를 선택해 주세요</option>
-            <option value="자기계발">자기계발</option>
-            <option value="경영/경제">경영/경제</option>
-            <option value="가정/육아">가정/육아</option>
-            <option value="수험서">수험서</option>
-          </select>
-        </ItemContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="title" content="책 정보 등록" />
-          <SearchInputContainer>
-            <SearchInputLabel>추천하는 책을 검색 후 등록해 주세요</SearchInputLabel>
-            <SearchInputButton>책 검색하기</SearchInputButton>
-          </SearchInputContainer>
-        </ItemContainer>
-        <ItemContainer>
-        <Label type="title" htmlFor="title" content="큐레이션 공개 여부" />
-          <RadioButtonContainer>
-            <input type="radio" id="select" name="radio"/>
-            <label htmlFor="select">공개</label>
-            <input type="radio" id="select2" name="radio"/>
-            <label htmlFor="select2">비공개</label>
-          </RadioButtonContainer>
-        </ItemContainer>
-        <ButtonContainer>
-          <CancelButton>
-            <Button type="cancel" content="취소" />
-          </CancelButton>
-          <PrimaryButton>
-            <Button type="primary" content="발행" />
-          </PrimaryButton>
-        </ButtonContainer>
-      </FormContainer>
-    </Container></>
+    <>
+      <TitleContainer>큐레이션 수정하기</TitleContainer>
+      <Container>
+        <FormContainer>
+          <ItemContainer>
+            <Label type="title" htmlFor="title" content="제목" />
+            <Input
+              id="title"
+              placeholder="큐레이션의 제목을 입력해 주세요"
+              width="100%"
+              color="#000"
+              value={titleValue}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setTitleValue(e.target.value)}
+            />
+          </ItemContainer>
+          <ItemContainer>
+            <Label type="text" htmlFor="emoji" content="이모지" />
+            <Input
+              id="emoji"
+              placeholder="큐레이션에 어울리는 이모지를 선택해 주세요"
+              width="100%"
+              color="#000"
+              value={emojiValue}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEmojiValue(e.target.value)}
+            />
+          </ItemContainer>
+          <ItemContainer>
+            <Label type="title" htmlFor="title" content="내용" />
+            <Label
+              type="content"
+              htmlFor="content"
+              content="마우스 드래그로 영역을 선택하면 서식을 수정하고, 이미지도 넣을 수 있어요!"
+            />
+            <QuillEditor
+              quillRef={quillRef}
+              curationContent={curationContent}
+              setcurationContent={setCurationContent}
+            />
+          </ItemContainer>
+          <ItemContainer>
+            <Label type="title" htmlFor="title" content="책 카테고리" />
+            <CustomSelect
+              optionData={[
+                { value: "카테고리를 선택해 주세요", key: "1" },
+                { value: "역사", key: "2" },
+                { value: "스포츠", key: "3" },
+                { value: "수험서", key: "4" }
+              ]}
+            />
+          </ItemContainer>
+          <ItemContainer>
+            <Label type="title" htmlFor="title" content="책 정보 등록" />
+            <SearchInputContainer>
+              <SearchInputLabel>추천하는 책을 검색 후 등록해 주세요</SearchInputLabel>
+              <SearchInputButton>책 검색하기</SearchInputButton>
+            </SearchInputContainer>
+          </ItemContainer>
+          <ItemContainer>
+            <Label type="title" htmlFor="title" content="큐레이션 공개 여부" />
+            <RadioButtonContainer>
+              <input type="radio" id="select" name="radio" />
+              <label htmlFor="select">공개</label>
+              <input type="radio" id="select2" name="radio" />
+              <label htmlFor="select2">비공개</label>
+            </RadioButtonContainer>
+          </ItemContainer>
+          <ButtonContainer>
+            <CancelButton>
+              <Button type="cancel" content="취소" />
+            </CancelButton>
+            <PrimaryButton>
+              <Button type="primary" content="발행" />
+            </PrimaryButton>
+          </ButtonContainer>
+        </FormContainer>
+      </Container>
+    </>
   );
 };
 
@@ -89,7 +134,7 @@ const Container = styled.div`
 
 const FormContainer = styled.div`
   background-color: #EFEFEF;
-  border-radius: 0.3rem;
+  border-radius: 2rem;
   padding: 0rem 3rem 2rem 3rem;
   width: 40rem;
   margin-bottom: 8rem;
@@ -127,7 +172,7 @@ const SearchInputLabel = styled.label`
   background-color: #ffffff;
   border-radius: 0.3rem;
   color: #757575;
-  font-size: 13px;
+  font-size: .8rem;
   font-weight: 100;
 `;
 
@@ -138,16 +183,73 @@ const SearchInputButton = styled.label`
   padding: 0.6rem;
   text-align: center;
   border: 1px solid #f8f7f7;
-  background-color:  #dbdbdb;
+  background-color:  #f8f7f7;
   border-radius: 0.3rem;
   color: #757575;
-  font-size: 13px;
+  font-size: .8rem;
   font-weight: 100;
+  &:hover {
+    background-color: #f8f7f7;
+  }
+`;
+
+const SelectBox = styled.div`
+  position: relative;
+  width: 100%;
+  padding: .6rem;
+  border-radius: .3rem;
+  background-color: #ffffff;
+  align-self: center;
+  cursor: pointer;
+  &::before {
+  content: "⌵";
+    position: absolute;
+    top: 1px;
+    right: 8px;
+    color: #3173f6;
+    font-size: 1.25rem;
+  }
+`;
+
+const CategoryLabel = styled.label`
+  font-size: .8rem;
+  margin: 5px;
+  text-align: center;
+`;
+
+const SelectOptions = styled.ul<{ show: boolean }>`
+  position: absolute;
+  list-style: none;
+  top: 2.4rem;
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  height: ${(props) => (props.show ? "147px" : "0")};
+  padding: 0;
+  border-radius: .3rem;
+  background-color: #f8f7f7;
+  color: #000000;
+`;
+
+const Option = styled.li`
+  font-size: .8rem;
+  padding: 12px;
+  transition: background-color 0.05s ease-in;
+  &:hover {
+    background-color: #ffffff;
+  }
 `;
 
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
+`;
+
+const RadioButtonContainer = styled.div`
+  margin: 0rem 3rem 3rem -0.3rem;
+  cursor: pointer;
+  font-size: 15px;
+  color: #757575;
 `;
 
 const CancelButton = styled.div`
@@ -156,13 +258,6 @@ const CancelButton = styled.div`
 
 const PrimaryButton = styled.div`
   margin: 10px;
-`;
-
-const RadioButtonContainer = styled.div`
-  margin: 0rem 3rem 3rem -0.3rem;
-  cursor: pointer;
-  font-size: 15px;
-  color: #757575;
 `;
 
 export default CurationWritePage;

--- a/client/src/styles/GlobalStyles.ts
+++ b/client/src/styles/GlobalStyles.ts
@@ -51,6 +51,14 @@ const GlobalStyles = createGlobalStyle`
   ol, ul{
     list-style: none;
   }
+
+  .ql-editor strong {
+  font-weight:bold;
+}
+
+.ql-editor em {
+  font-style: italic;
+  }
 `;
 
 export default GlobalStyles;


### PR DESCRIPTION
## 개요

- 큐레이션 수정 페이지의 레이아웃을 작업 했습니다.

## 작업사항

- 웹 에디터 React Quill을 적용했습니다.
- 책 카테고리를 선택할 수 있도록 select box를 적용했습니다.
- 추후 책 API를 활용해 정보를 등록할 수 있도록 검색 버튼을 적용했습니다.
- 큐레이션 공개 여부를 선택할 수 있도록 라디오 버튼을 적용했습니다.
- 그 외 title, input, button은 공통 컴포넌트를 사용했습니다.

### 참고사항

- 카테고리 부분은 책 카테고리가 다양하므로 추후 별도의 컴포넌트로 뺄 예정입니다.
- 책 API 기능과 모달이 구현되면 추후 함께 적용 예정입니다.
- 제목과 이미지가 같은 input창에 입력되던 문제는 value를 다르게 하여 해결했습니다.
- 내용 input 창에 bold와 italic이 적용되지 않던 문제는 GlobalStyles.ts 하단에 strong과 em을 추가해 해결했습니다.

### 스크린샷

https://github.com/codestates-seb/seb44_main_004/assets/123397411/884600f7-2d4f-48b7-ba8d-64f29e7ca67d

## 리뷰 요청사항

- 도움 주셔서 감사합니다! 피드백은 언제나 환영입니다.
- 확인해 주시면 큐레이션 '작성' 페이지도 위 레이아웃 적용해 PR 올리겠습니다.
