### PR TITLE
feat: 큐레이션 삭제 기능

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -36,7 +36,7 @@ public class CurationController {
     @PostMapping
     public ResponseEntity postCuration(@RequestBody @Valid CurationPostDto postDto){
 
-        Curation savedCuration = curationService.createCuration(mapper.curationPostDtoToCuration(postDto), getAuthentication());
+        Curation savedCuration = curationService.createCuration(mapper.curationPostDtoToCuration(postDto), getAuthenticatedEmail());
         URI uri = UriCreator.createUri(CURATION_DEFAULT_URL, savedCuration.getCurationId());
 
         return ResponseEntity.created(uri).build();
@@ -46,13 +46,22 @@ public class CurationController {
     public ResponseEntity patchCuration(@RequestBody @Valid CurationPatchDto patchDto,
                                         @PathVariable("curation-id") @Positive long curationId){
 
-        Curation updatedCuration = curationService.updateCuration(patchDto, curationId, getAuthentication());
+        Curation updatedCuration = curationService.updateCuration(patchDto, curationId, getAuthenticatedEmail());
         URI uri = UriCreator.createUri(CURATION_DEFAULT_URL, updatedCuration.getCurationId());
 
         return ResponseEntity.ok().header("Location", uri.getPath()).build();
     }
 
-    private Authentication getAuthentication(){
-        return SecurityContextHolder.getContext().getAuthentication();
+//    @DeleteMapping("/{curation-id}")
+//    public ResponseEntity deleteCuration(@PathVariable("curation-id") @Positive long curationId){
+//
+//    }
+
+    private String getAuthenticatedEmail(){
+        return SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal()
+                .toString();
     }
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -52,10 +52,11 @@ public class CurationController {
         return ResponseEntity.ok().header("Location", uri.getPath()).build();
     }
 
-//    @DeleteMapping("/{curation-id}")
-//    public ResponseEntity deleteCuration(@PathVariable("curation-id") @Positive long curationId){
-//
-//    }
+    @DeleteMapping("/{curation-id}")
+    public ResponseEntity deleteCuration(@PathVariable("curation-id") @Positive long curationId){
+        curationService.deleteCuration(curationId, getAuthenticatedEmail());
+        return ResponseEntity.noContent().build();
+    }
 
     private String getAuthenticatedEmail(){
         return SecurityContextHolder

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -21,17 +21,16 @@ public class CurationService {
     private final CurationRepository curationRepository;
     private final MemberService memberService;
 
-    public Curation createCuration(Curation curation, Authentication authentication){
+    public Curation createCuration(Curation curation, String authenticatedEmail){
         //TODO: 추후 MemberService 에서 검증된 멤버를 리턴하는 메소드 필요
 
         curation.setMember(
-                memberService.findVerifiedMemberByEmail(
-                        authentication.getPrincipal().toString()));
+                memberService.findVerifiedMemberByEmail(authenticatedEmail));
 
         return curationRepository.save(curation);
     }
 
-    public Curation updateCuration(CurationPatchDto patchDto, long curationId, Authentication authentication){
+    public Curation updateCuration(CurationPatchDto patchDto, long curationId, String authenticatedEmail){
 
         Curation findCuration = findVerifiedCurationById(curationId);
 
@@ -40,7 +39,7 @@ public class CurationService {
         }
 
         if(findCuration.getMember().getEmail()
-                .equals(authentication.getPrincipal().toString()) == false) {
+                .equals(authenticatedEmail) == false) {
             throw new BusinessLogicException(ExceptionCode.CURATION_CANNOT_CHANGE);
         }
 
@@ -48,6 +47,10 @@ public class CurationService {
 
         return curationRepository.save(findCuration);
     }
+
+//    public Curation deleteCuration(long curationId, Authentication authentication){
+//
+//    }
 
     public Curation findVerifiedCurationById(long curationId) {
         Optional<Curation> optionalCuration = curationRepository.findById(curationId);

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -50,9 +50,16 @@ public class CurationService {
 
     public void deleteCuration(long curationId, String authenticatedEmail){
         Curation findCuration = findVerifiedCurationById(curationId);
+
         if (findCuration.getMember().getEmail().equals(authenticatedEmail) == false){
             throw new BusinessLogicException(ExceptionCode.CURATION_CANNOT_DELETE);
         }
+
+        // 이미 삭제된 큐레이션을 또 삭제하려는 요청에 대한 에러처리
+        if (findCuration.getCurationStatus() == Curation.CurationStatus.CURATION_DELETE){
+            throw new BusinessLogicException(ExceptionCode.CURATION_HAS_BEEN_DELETED);
+        }
+
         findCuration.setCurationStatus(Curation.CurationStatus.CURATION_DELETE);
     }
 

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -48,9 +48,13 @@ public class CurationService {
         return curationRepository.save(findCuration);
     }
 
-//    public Curation deleteCuration(long curationId, Authentication authentication){
-//
-//    }
+    public void deleteCuration(long curationId, String authenticatedEmail){
+        Curation findCuration = findVerifiedCurationById(curationId);
+        if (findCuration.getMember().getEmail().equals(authenticatedEmail) == false){
+            throw new BusinessLogicException(ExceptionCode.CURATION_CANNOT_DELETE);
+        }
+        findCuration.setCurationStatus(Curation.CurationStatus.CURATION_DELETE);
+    }
 
     public Curation findVerifiedCurationById(long curationId) {
         Optional<Curation> optionalCuration = curationRepository.findById(curationId);

--- a/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
@@ -14,7 +14,7 @@ public enum ExceptionCode {
     CURATION_ACCESS_DENIED(403,"큐레이션을 열람 할 수 없습니다."),
     CURATION_CANNOT_CHANGE(403,"큐레이션을 수정 할 수 없습니다."),
     CURATION_CANNOT_DELETE(403,"큐레이션을 삭제 할 수 없습니다."),
-    CURATION_HAS_BEEN_DELETED(403,"큐레이션이 삭제 되었습니다."),
+    CURATION_HAS_BEEN_DELETED(404,"이미 삭제된 큐레이션입니다."),
     REPLY_NOT_FOUND(404,"댓글을 찾을 수 없습니다."),
     REPLY_CANNOT_CHANGE(403,"댓글을 수정 할 수 없습니다."),
     REPLY_CANNOT_DELETE(403,"댓글을 삭제 할 수 없습니다."),


### PR DESCRIPTION
## 개요
- 로그인한 사용자가 본인이 작성한 큐레이션을 삭제하는 기능

## 작업사항
- 로그인한 사용자와 큐레이션 작성자가 일치하는 지 검증
- 이미 삭제된 큐레이션에 접근하는 경우 `BusinesLogicException` 발생
- Exception 코드 변경 `_CURATION_HAS_BEEN_DELETED_`
  - 코드 403 -> 404
  - 메세지 "큐레이션이 삭제되었습니다." -> "이미 삭제된 큐레이션입니다."
  - 이유 : 이미 삭제된 큐레이션에 접근하는 요청에 대한 에러코드이기 때문에 위와 같이 변경되야 된다고 생각했습니다.
- 사용자 검증이 완료되었다면 `CurationStatus` active -> delete 로 변경

### 참고사항
- 컨트롤러에 Authentication 을 얻기위해 `private` 메소드로 만든 부분을 리팩토링해서 검증된 email을 리턴해주는 거로 변경했습니다.

### 스크린샷
- gif, 이미지 파일 등

## 리뷰 요청사항
- 개선해야하거나 궁금하신점 리뷰로 남겨주세요!