### PR TITLE
Feat/fe-curationCard 큐레이션 카드 컴포넌트 레이아웃 수정

### DIFF
--- a/client/src/components/CurationCard.tsx
+++ b/client/src/components/CurationCard.tsx
@@ -36,7 +36,7 @@ const CurationCard = ({type, emoji, title, content, likes, nickname, memberId}:C
 
 }
 const CardContainer = styled.div<CurationProps>`
-    width: ${(props) => props.type === "main" ? `calc(33.33% - 1rem)` : `calc(50% - 1rem)`};
+    width: ${(props) => props.type === "mypage" ? `calc(50% - 1rem)` : `calc(33.33% - 1rem)`};
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/client/src/components/CurationCard.tsx
+++ b/client/src/components/CurationCard.tsx
@@ -1,26 +1,28 @@
 import tw from "twin.macro";
 import styled from "styled-components";
+
 import {AiFillHeart, AiOutlineHeart}from "react-icons/ai";
 
 interface CurationProps {
+    type?: string,
     emoji?: string,
     title?: string,
     content?: string,
     likes?: number,
     nickname?: string,
-    memberId?: string,
+    memberId?: number,
 }
-const CurationCard = ({emoji, title, content, likes, nickname, memberId}:CurationProps) => {
+const CurationCard = ({type, emoji, title, content, likes, nickname, memberId}:CurationProps) => {
 
     //클릭시 
     return(
-        <CardContainer>
+        <CardContainer type={type}>
             <Item>{emoji}</Item>
             <Item>{title}</Item>
             <Item>{content}</Item>
             <Item>
                 <div className="likes">
-                    <AiFillHeart size="1.5rem"/>
+                    <AiFillHeart />
                     좋아요 {likes}개
                 </div>
                 <div className="nickname">
@@ -33,15 +35,14 @@ const CurationCard = ({emoji, title, content, likes, nickname, memberId}:Curatio
     )
 
 }
-const CardContainer = styled.div`
-    width: calc(33.33%);
-
+const CardContainer = styled.div<CurationProps>`
+    width: ${(props) => props.type === "main" ? `calc(33.33% - 1rem)` : `calc(50% - 1rem)`};
     display: flex;
     flex-direction: column;
     align-items: center;
     padding: 1.5rem 2rem ;
-    margin: 1rem;
-    font-size: 1.2vw;
+    margin-bottom: 1.8rem;
+    font-size: 0.8vw;
     border-radius: 0.625rem;
     background-color: #D9E1E8;
     box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
@@ -59,10 +60,10 @@ const Item = styled.div`
     margin: 0.5rem 0;
     
     &:first-child {
-        font-size: 2vw;
+        font-size: 1.3vw;
     }
     &:nth-child(2){
-        font-size: 1.4vw;
+        font-size: 1vw;
         font-weight: 600;
     }
     &:nth-child(3){
@@ -97,3 +98,5 @@ const Item = styled.div`
 
 `
 export default CurationCard;
+
+

--- a/client/src/components/SubCuratorCard.tsx
+++ b/client/src/components/SubCuratorCard.tsx
@@ -4,7 +4,14 @@ import styled from "styled-components";
 import {BsPersonCircle} from "react-icons/bs"
 import {RxDividerVertical} from "react-icons/rx";
 
-const SubCuratorCard = () => {
+interface CuratorProps{
+    nickname?: string,
+    subscribers?: number,
+    curations?: number,
+    introduce?: string,
+}
+const SubCuratorCard = ({nickname, subscribers, curations, introduce}: CuratorProps) => {
+
 
     return(
         <CuratorContainer>
@@ -17,20 +24,19 @@ const SubCuratorCard = () => {
                <CuratorInfo>
                    
                     <UserNickname>
-                        앙꼬
+                        {nickname}
                     </UserNickname>
                     <UserInfo>
-                        구독자 10명
+                       구독자 {subscribers} 명
                     </UserInfo>
                     <RxDividerVertical size="1.2rem"/>
                     <UserInfo>
-                        작성한 큐레이션 5개
+                        작성한 큐레이션 {curations}개
                     </UserInfo>
                     
                 </CuratorInfo>
-               <CuratorIntro>
-                    안녕하세요. 앙꼬 입니다. 팥앙꼬를 좋아합니다.
-                    안녕하세요. 앙꼬 입니다. 팥앙꼬를 좋아합니다.
+               <CuratorIntro id="introduce">
+                    {introduce}
                 </CuratorIntro>
                 
             </CuratorRight>
@@ -39,20 +45,27 @@ const SubCuratorCard = () => {
 }
 
 const CuratorContainer = styled.div`
+    width: calc(50% - 1rem);
+
     display: flex;
     align-items: center;
     padding: 1.3rem 2rem ;
-    margin: 1rem;
+    margin: 1rem 0;
     
     font-size: 1.2vw;
     border-radius: 0.625rem;
     background-color: #D9E1E8;
     box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+    
     cursor: pointer;
 
     &:hover{
         background-color: ${({theme}) => theme.colors.mainPastelBlue300};
         color: white;
+
+        div#introduce{
+            color: white;
+        }
     }   
     svg{
         display:flex;
@@ -77,14 +90,22 @@ const CuratorInfo = tw.div`
     items-center
     gap-2
 `;
-const UserNickname = tw.p`
-    text-lg
+const UserNickname = styled.div`
+   font-size: 1.2vw;
+   font-weight: 500;
 `;
-const UserInfo = tw.p`
-    
+const UserInfo = styled.div`
+    font-size: 0.8vw;
 `;
-const CuratorIntro = tw.div`
-    
+const CuratorIntro = styled.div`
+    font-size: 0.8vw;
+    color: #595656;
+    overflow: hidden;
+    white-space: normal;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
 `;
 
 export default SubCuratorCard;


### PR DESCRIPTION
## 개요
- 마이페이지 연결 작업을 하면서 호환성에 맞게 큐레이션 카드 컴포넌트를 수정했습니다.

## 작업사항
- 큐레이션 카드 컴포넌트
  - type 속성을 추가하여 페이지에 맞게 width 가 조절되도록 변경하였습니다.
  - 폰트 사이즈를 변경하였습니다. 

- 구독 큐레이터 카드 컴포넌트
  - props 로 닉네임, 구독자수, 작성한 큐레이터 수, 소개글 을 받아오도록 설정하였습니다.
  - 디스코드의 의견을 반영하여 width 를 변경하였습니다. 
  - 소개글 부분은 말줄임이 되도록 설정해 놓았습니다.
  
## 참고사항
(아토미한 컴포넌트다 보니 연결 작업 시 수정 사항이 자주 발생할 것 같습니다.)

**추가! card 폴더생성해서 옮긴다는 것을 깜빡했습니다. 다음 수정 사항에 꼭 반영하도록 하겠습니다.** 
- 큐레이션 카드 컴포넌트
  - type 속성을 optional 로 설정하였고, ```mypage``` 일 경우와 그렇지 않은 경우로 나누었습니다.   
  
## 스크린샷
 - 큐레이션 카드 컴포넌트
 
 |마이페이지인 경우| 메인페이지나 큐레이션 리스트 페이지인 경우|
|:--:|:--:|
|<img width="1283" alt="스크린샷 2023-07-06 오후 2 06 44" src="https://github.com/codestates-seb/seb44_main_004/assets/76391160/e97241e7-34e7-49b2-8ee5-1796b0c76f73" > | <img width="1146" alt="스크린샷 2023-07-06 오후 2 10 30" src="https://github.com/codestates-seb/seb44_main_004/assets/76391160/9988fe45-4ad2-4ab2-9dbb-440a1565c8f5"> |

- 큐레이터 카드 컴포넌트 
<img width="1447" alt="스크린샷 2023-07-06 오후 1 08 47" src="https://github.com/codestates-seb/seb44_main_004/assets/76391160/0b0d4900-3589-4e03-966f-010633202409">


## 리뷰 요청사항
피드백 주시면 감사하겠습니다!