### PR TITLE
feat: 댓글수정,삭제 구현 완료

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/reply/controller/ReplyController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/controller/ReplyController.java
@@ -1,5 +1,6 @@
 package com.seb_main_004.whosbook.reply.controller;
 
+import com.seb_main_004.whosbook.reply.dto.ReplyPatchDto;
 import com.seb_main_004.whosbook.reply.dto.ReplyPostDto;
 import com.seb_main_004.whosbook.reply.entity.Reply;
 import com.seb_main_004.whosbook.reply.mapper.ReplyMapper;
@@ -7,12 +8,10 @@ import com.seb_main_004.whosbook.reply.service.ReplyService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 
 @RestController
 @RequestMapping("/curations")
@@ -26,14 +25,45 @@ public class ReplyController {
         this.replyMapper = replyMapper;
     }
 
+    //댓글 작성
     @PostMapping("replys")
-    public ResponseEntity postReply(@Valid @RequestBody ReplyPostDto replyPostDto, Authentication authentication){
+    public ResponseEntity postReply(@Valid @RequestBody ReplyPostDto replyPostDto,
+                                    Authentication authentication){
 
         String userEmail= authentication.getPrincipal().toString();
 
         Reply reply= replyService.createReply(replyMapper.replyToPostDtoToReply(replyPostDto), userEmail);
 
         return new ResponseEntity(replyMapper.replyToReplyResponseDto(reply), HttpStatus.CREATED);
+
+
+    }
+
+    //댓글 수정
+    @PatchMapping("replys/{reply-id}")
+    public ResponseEntity updateReply(@Positive @PathVariable("reply-id") long replyId,@Valid @RequestBody
+                                          ReplyPatchDto replyPatchDto,
+                                      Authentication authentication){
+
+        String userEmail= authentication.getPrincipal().toString();
+
+        Reply patchReply= replyService.updateReply(replyMapper.replyToPatchToReply(replyPatchDto),userEmail);
+
+        return new ResponseEntity(replyMapper.replyToReplyResponseDto(patchReply),HttpStatus.OK);
+
+    }
+
+    //댓글 삭제
+    @DeleteMapping("replys/{reply-id}")
+    public ResponseEntity deleteReply(@Positive @PathVariable("reply-id") long replyId,@Valid
+                                      Authentication authentication){
+
+        String userEmail= authentication.getPrincipal().toString();
+
+        replyService.deleteReply(replyId,userEmail);
+
+        return  new ResponseEntity(HttpStatus.NO_CONTENT);
+
 
 
     }

--- a/server/src/main/java/com/seb_main_004/whosbook/reply/dto/ReplyPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/dto/ReplyPatchDto.java
@@ -1,4 +1,9 @@
 package com.seb_main_004.whosbook.reply.dto;
 
+import lombok.Data;
+
+@Data
 public class ReplyPatchDto {
+
+    private String content;
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/reply/mapper/ReplyMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/mapper/ReplyMapper.java
@@ -1,5 +1,6 @@
 package com.seb_main_004.whosbook.reply.mapper;
 
+import com.seb_main_004.whosbook.reply.dto.ReplyPatchDto;
 import com.seb_main_004.whosbook.reply.dto.ReplyPostDto;
 import com.seb_main_004.whosbook.reply.dto.ReplyResponseDto;
 import com.seb_main_004.whosbook.reply.entity.Reply;
@@ -10,4 +11,6 @@ public interface ReplyMapper {
     Reply replyToPostDtoToReply(ReplyPostDto replyPostDto);
 
     ReplyResponseDto replyToReplyResponseDto(Reply reply);
+
+    Reply replyToPatchToReply(ReplyPatchDto replyPatchDto);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/reply/service/ReplyService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/service/ReplyService.java
@@ -1,12 +1,15 @@
 package com.seb_main_004.whosbook.reply.service;
 
 
+import com.seb_main_004.whosbook.exception.BusinessLogicException;
+import com.seb_main_004.whosbook.exception.ExceptionCode;
 import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.service.MemberService;
 import com.seb_main_004.whosbook.reply.entity.Reply;
 import com.seb_main_004.whosbook.reply.repository.ReplyRepository;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 public class ReplyService {
@@ -22,16 +25,52 @@ public class ReplyService {
 
     public Reply createReply(Reply reply, String userEmail){
 
-        //로그인한 사용자인지아닌지 검증(추후 로직 추가 예정)
-
-        //Member member= memberService.
+        //로그인한 사용자인지아닌지 검증
+        Member findEmail= memberService.findVerifiedMemberByEmail(userEmail);
 
         //큐레이션 아이디를 가져옴(연관관계맵핑후 추후 로직 추가 예정)
+
+        //reply와 member의 연관관계매핑을 통해 reply에 회원을 추가해야함.
 
         //댓글저장
         Reply savedReply= replyRepository.save(reply);
 
         return  savedReply;
+
+    }
+
+    public Reply updateReply(Reply reply,String userEmail) {
+
+        Member findEmail= memberService.findVerifiedMemberByEmail(userEmail);
+        //큐레이션 아이디를 가져옴(연관관계맵핑후 추후 로직 추가 예정)
+
+        //reply와 member의 연관관계매핑을 통해 reply에 회원을 추가해야함.
+
+        Reply updateReply= replyRepository.save(reply);
+
+        return updateReply;
+
+    }
+
+    public void deleteReply(long replyId, String userEmail) {
+
+         Reply findReply= findVerifiedReply(replyId); //유효한 댓글인지 검증
+
+         replyRepository.delete(findReply);
+
+    }
+    //입력된 댓글이 유효한지 검증
+    public Reply findVerifiedReply(long replyId){
+
+        Optional<Reply> reply= replyRepository.findById(replyId);
+
+        return reply.orElseThrow(()-> new BusinessLogicException(ExceptionCode.REPLY_NOT_FOUND));
+    }
+
+    //입렫된 댓글이 findReply의 회원과 로그인된 회원이 일치하는지 확
+    private void verifyUser(String userEmail, Reply reply) {
+
+        //큐레이션과 회원의 연관관계맵핑후 설정
 
     }
 }


### PR DESCRIPTION
개요
-큐레이션 단일상세조회에서 로그인한 사용자가 쓴 댓글을 수정,삭제할수있습니다

작업사항
-댓글 수정,삭제 구현
-로그인한 사용자가 댓글 수정,삭제할수있게인증 처리까지 구현

참고사항
-ReplyService에서 로그인한사용자와댓글을 작성한 사용자가 일치하는지 검증하는 로직 구현은 연관관계 맵핑후 구현할 예정

리뷰요청사항
-참고사항이외에 처리할부분이있는지 리뷰 부탁드립니다