### PR TITLE
feat: 큐레이션 단일 상세 조회 기능 구현

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -58,6 +58,14 @@ public class CurationController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/{curation-id}")
+    public ResponseEntity getCuration(@PathVariable("curation-id") @Positive long curationId) {
+        log.info("큐레이션 단일 상세조회 요청 확인");
+        Curation curation = curationService.getCuration(curationId, getAuthenticatedEmail());
+
+        return new ResponseEntity(mapper.curationToCurationSingleDetailResponseDto(curation), HttpStatus.OK);
+    }
+
     private String getAuthenticatedEmail(){
         return SecurityContextHolder
                 .getContext()

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationSingleDetailResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationSingleDetailResponseDto.java
@@ -1,0 +1,23 @@
+package com.seb_main_004.whosbook.curation.dto;
+
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.member.dto.CuratorResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class CurationSingleDetailResponseDto {
+    private CuratorResponseDto curator;
+    private Boolean isSubscribed;
+    private int like;
+    private long curationId;
+    private String emoji;
+    private String title;
+    private String content;
+    private Curation.Visibility visibility;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -3,11 +3,13 @@ package com.seb_main_004.whosbook.curation.entity;
 
 import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
 import com.seb_main_004.whosbook.member.entity.Member;
+import com.seb_main_004.whosbook.reply.entity.Reply;
 import lombok.Data;
 import lombok.Getter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Data
@@ -36,6 +38,9 @@ public class Curation {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "curation", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    private List<Reply> replies;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
@@ -76,6 +81,15 @@ public class Curation {
         this.content = patchDto.getContent();
         this.visibility = patchDto.getVisibility();
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void addReply(Reply reply){
+        //TODO: reply 맵핑 완료시 양방향 등록 로직 추가
+        this.replies.add(reply);
+    }
+
+    public boolean isDeleted(){
+        return this.curationStatus == CurationStatus.CURATION_DELETE;
     }
 
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -1,7 +1,11 @@
 package com.seb_main_004.whosbook.curation.mapper;
 
 import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
+import com.seb_main_004.whosbook.curation.dto.CurationSingleDetailResponseDto;
 import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.member.dto.CuratorResponseDto;
+import com.seb_main_004.whosbook.member.dto.MemberResponseDto;
+import com.seb_main_004.whosbook.member.entity.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -9,4 +13,27 @@ import org.mapstruct.Mapping;
 public interface CurationMapper {
 
     Curation curationPostDtoToCuration(CurationPostDto postDto);
+    default CurationSingleDetailResponseDto curationToCurationSingleDetailResponseDto(Curation curation){
+        Member member = curation.getMember();
+
+        CuratorResponseDto curator = CuratorResponseDto.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .build();
+
+        return CurationSingleDetailResponseDto.builder()
+                .curator(curator)
+                .isSubscribed(true)
+                .like(10)
+                .curationId(curation.getCurationId())
+                .emoji(curation.getEmoji())
+                .title(curation.getTitle())
+                .content(curation.getContent())
+                .visibility(curation.getVisibility())
+                .createdAt(curation.getCreatedAt())
+                .updatedAt(curation.getUpdatedAt())
+                .build();
+    }
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/CuratorResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/CuratorResponseDto.java
@@ -1,0 +1,20 @@
+package com.seb_main_004.whosbook.member.dto;
+
+import com.seb_main_004.whosbook.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CuratorResponseDto {
+    private long memberId;
+
+    private String email;
+
+    private String nickname;
+
+    private String introduction;
+
+//    회원가입 시 이미지 업로드를 위한 변수로서, 추후 구현
+//    private String image;
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/reply/entity/Reply.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/entity/Reply.java
@@ -1,12 +1,10 @@
 package com.seb_main_004.whosbook.reply.entity;
 
 
+import com.seb_main_004.whosbook.curation.entity.Curation;
 import lombok.Data;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
@@ -22,6 +20,9 @@ public class Reply {
     private LocalDateTime createdAt=LocalDateTime.now();
 
     private LocalDateTime updatedAt=LocalDateTime.now();
+    @ManyToOne
+    @JoinColumn(name = "curation_id")
+    private Curation curation;
 
 
 }


### PR DESCRIPTION
## 개요
- HTTP GET 메소드를 통한 큐레이션 단일 상세 조회 API

## 작업사항
- 단일 상세 조회 응답을 위한 `CurationSingleDetailResponseDto` 구현
- `CurationMapper` 에 맵핑 메소드 추가
- `Reply` 엔티티와 `Curation` 엔티티 연관관계 맵핑
- `CuratorResponseDto` 생성

### 참고사항

### 스크린샷
- gif, 이미지 파일 등

## 리뷰 요청사항
- 연관관계 맵핑이라 문제 될게 없는지 확인 부탁드립니다.
