### PR TITLE
[Client] 공통 버튼 컴포넌트에 detail 스타일 추가

### DIFF
--- a/client/src/components/buttons/Button.tsx
+++ b/client/src/components/buttons/Button.tsx
@@ -9,7 +9,7 @@ import styled, { css } from 'styled-components';
  *  - 커스텀 버튼 사용시 width, color, backgroundColor, padding, hoverColor, hoverBackgroundColor, borderColor, hoverBorderColor
  */
 
-export type ButtonType = 'primary' | 'subscribe' | 'cancel' | 'publication' | 'basic';
+export type ButtonType = 'primary' | 'subscribe' | 'cancel' | 'publication' | 'basic' | 'detail' ;
 interface ButtonProps {
   type?: ButtonType;
   width?: string;
@@ -146,6 +146,19 @@ const StyledButton = styled.button<ButtonProps>`
         color: ${({ theme }) => theme.colors.mainWhiteColor};
         background-color: ${({ theme }) => theme.colors.mainGrayBlue};
       }
+
+      &:active {
+        transform: scale(0.95);
+      }
+    `}
+
+${({ type }) =>
+    type === 'detail' &&
+    css`
+      color: ${({ theme }) => theme.colors.mainLightBlack100};
+      background-color: ${({ theme }) => theme.colors.mainWhiteColor};
+      border: 0.12rem solid ${({ theme }) => theme.colors.mainLightBlack100};
+      transition: transform 0.1s;
 
       &:active {
         transform: scale(0.95);


### PR DESCRIPTION
## 개요
- 공통 버튼 컴포넌트에 detail 버튼 스타일을 추가했습니다.

## 작업사항
- 공통 버튼 컴포넌트에 더보기 버튼 (type='detail') 으로 스타일을 적용하였습니다.

## 참고사항
- 단순히 댓글을 더 불러오는 기능을 하는 버튼이기에, 클릭 및 hover 시 색이 변하는 스타일을 적용하진 않았습니다.

## 사용법
```tsx
<Button type="detail" content="더보기" />
```

## 스크린샷

https://github.com/codestates-seb/seb44_main_004/assets/123397411/488ace3d-f3a3-4c27-a7c1-e01561aa07f9

## 리뷰 요청사항
- 추가 수정할 부분이 있을 지 조언 부탁드립니다.

<br/>