### PR TITLE
[Client] 공통 버튼 컴포넌트에 category 스타일 추가

### DIFF
--- a/client/src/components/buttons/Button.tsx
+++ b/client/src/components/buttons/Button.tsx
@@ -9,7 +9,7 @@ import styled, { css } from 'styled-components';
  *  - 커스텀 버튼 사용시 width, color, backgroundColor, padding, hoverColor, hoverBackgroundColor, borderColor, hoverBorderColor
  */
 
-export type ButtonType = 'primary' | 'subscribe' | 'cancel' | 'publication' | 'basic';
+export type ButtonType = 'primary' | 'subscribe' | 'cancel' | 'publication' | 'basic' | 'detail' | 'category' ;
 interface ButtonProps {
   type?: ButtonType;
   width?: string;
@@ -151,6 +151,39 @@ const StyledButton = styled.button<ButtonProps>`
         transform: scale(0.95);
       }
     `}
+
+  ${({ type }) =>
+    type === 'detail' &&
+    css`
+      color: ${({ theme }) => theme.colors.mainLightBlack100};
+      background-color: ${({ theme }) => theme.colors.mainWhiteColor};
+      border: 0.12rem solid ${({ theme }) => theme.colors.mainLightBlack100};
+      transition: transform 0.1s;
+
+      &:active {
+        transform: scale(0.95);
+      }
+    `}
+
+  ${({ type }) =>
+  type === 'category' &&
+  css`
+    color: ${({ theme }) => theme.colors.mainLightBlack200};
+    background-color: ${({ theme }) => theme.colors.mainLightGray};
+    transition: transform 0.2s;
+    box-shadow: 0 .2rem .2rem #ADACAC, 0 .2rem .2rem #ADACAC;
+    border-radius: 1rem;
+    width: 120px;
+
+    &:hover {
+      color: ${({ theme }) => theme.colors.mainWhiteColor};
+      background-color: ${({ theme }) => theme.colors.mainPastelBlue300};
+    }
+
+    &:active {
+      transform: scale(0.95);
+    }
+  `}
 `;
 
 export default Button;

--- a/client/src/styles/theme.ts
+++ b/client/src/styles/theme.ts
@@ -10,7 +10,7 @@ export const colors = {
   mainPastelBlue400: '#4a55a2',
   mainBlackColor: '#000000',
   mainLightBlack100: '#282c37',
-  mainLightBlack200: '2b2b2b',
+  mainLightBlack200: '#2b2b2b',
   mainWhiteColor: '#ffffff',
   mainGrayBlue: '#9baec8',
   mainLightGray: '#d9e1e8',


### PR DESCRIPTION
## 개요
- 공통 버튼 컴포넌트에 category 버튼 스타일을 추가했습니다.

## 작업사항
- 공통 버튼 컴포넌트에 카테고리 버튼 (type='category') 으로 스타일을 적용하였습니다.
- 더불어, theme.ts의 mainLightBlack200에 `#`을 추가했습니다.

## 참고사항
- 공통 스타일에서 추가로 width, radius, shadow 스타일을 적용했습니다.

## 사용법
```tsx
<Button type="category" content="경영 / 경제" />
```

## 스크린샷

https://github.com/codestates-seb/seb44_main_004/assets/123397411/cd2bfe2a-f178-4431-ab7c-07c999a4870f

## 리뷰 요청사항
- 피드백은 언제나 환영입니다!

<br/>