### PR TITLE
fix: 큐레이션 삭제 상태가 데이터베이스에 저장이 되지 않는 문제 해결

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -58,6 +58,7 @@ public class CurationService {
         checkCurationIsDeleted(curation);
 
         curation.setCurationStatus(Curation.CurationStatus.CURATION_DELETE);
+        curationRepository.save(curation);
     }
 
     public Curation getCuration(long curationId, String authenticatedEmail) {


### PR DESCRIPTION
## 개요
- 큐레이션 삭제 상태가 데이터베이스에 저장되지 않는 문제 해결

## 작업사항
- `CurationService` 단에 수정된 `Curation` 엔티티를 리파지토리를 통해 데이터 베이스에 저장하는 로직 추가

### 참고사항
- 스크럼 때 컨펌을 받아 바로 머지 하겠습니다

### 스크린샷
- gif, 이미지 파일 등

## 리뷰 요청사항
- 