### PR TITLE
feat: NEW 큐레이션 리스트 조회 기능추가

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -5,9 +5,11 @@ import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import com.seb_main_004.whosbook.curation.mapper.CurationMapper;
 import com.seb_main_004.whosbook.curation.service.CurationService;
+import com.seb_main_004.whosbook.dto.MultiResponseDto;
 import com.seb_main_004.whosbook.utils.UriCreator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @Slf4j
@@ -64,6 +67,16 @@ public class CurationController {
         Curation curation = curationService.getCuration(curationId, getAuthenticatedEmail());
 
         return new ResponseEntity(mapper.curationToCurationSingleDetailResponseDto(curation), HttpStatus.OK);
+    }
+
+    @GetMapping("/new")
+    public ResponseEntity getNewCurationList(@RequestParam("page") int page,
+                                             @RequestParam("size") int size){
+        Page<Curation> curationPage = curationService.getNewCurations(page - 1, size);
+        List<Curation> curations = curationPage.getContent();
+        return new ResponseEntity(new MultiResponseDto<>(
+                mapper.curationsToCurationListResponseDtos(curations), curationPage),
+                HttpStatus.OK);
     }
 
     private String getAuthenticatedEmail(){

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationListResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationListResponseDto.java
@@ -1,0 +1,20 @@
+package com.seb_main_004.whosbook.curation.dto;
+
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.member.dto.CuratorResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+@Builder
+@Getter
+public class CurationListResponseDto {
+    private CuratorResponseDto curator;
+    private int like;
+    private long curationId;
+    private String emoji;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -1,13 +1,18 @@
 package com.seb_main_004.whosbook.curation.mapper;
 
+import com.seb_main_004.whosbook.curation.dto.CurationListResponseDto;
 import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
 import com.seb_main_004.whosbook.curation.dto.CurationSingleDetailResponseDto;
 import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.curation.repository.CurationRepository;
 import com.seb_main_004.whosbook.member.dto.CuratorResponseDto;
 import com.seb_main_004.whosbook.member.dto.MemberResponseDto;
 import com.seb_main_004.whosbook.member.entity.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface CurationMapper {
@@ -16,12 +21,8 @@ public interface CurationMapper {
     default CurationSingleDetailResponseDto curationToCurationSingleDetailResponseDto(Curation curation){
         Member member = curation.getMember();
 
-        CuratorResponseDto curator = CuratorResponseDto.builder()
-                .memberId(member.getMemberId())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .introduction(member.getIntroduction())
-                .build();
+        CuratorResponseDto curator = memberToCuratorResponseDto(member);
+
 
         return CurationSingleDetailResponseDto.builder()
                 .curator(curator)
@@ -32,6 +33,34 @@ public interface CurationMapper {
                 .title(curation.getTitle())
                 .content(curation.getContent())
                 .visibility(curation.getVisibility())
+                .createdAt(curation.getCreatedAt())
+                .updatedAt(curation.getUpdatedAt())
+                .build();
+    }
+
+    default CuratorResponseDto memberToCuratorResponseDto(Member member){
+        return CuratorResponseDto.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .introduction(member.getIntroduction())
+                .build();
+    }
+
+    default List<CurationListResponseDto> curationsToCurationListResponseDtos(List<Curation> curations){
+        return curations.stream()
+                .map(curation -> curationToCurationListResponseDto(curation))
+                .collect(Collectors.toList());
+    }
+
+    default CurationListResponseDto curationToCurationListResponseDto(Curation curation){
+        return CurationListResponseDto.builder()
+                .curator(memberToCuratorResponseDto(curation.getMember()))
+                .like(15)
+                .curationId(curation.getCurationId())
+                .emoji(curation.getEmoji())
+                .title(curation.getTitle())
+                .content(curation.getContent())
                 .createdAt(curation.getCreatedAt())
                 .updatedAt(curation.getUpdatedAt())
                 .build();

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
@@ -1,9 +1,17 @@
 package com.seb_main_004.whosbook.curation.repository;
 
 import com.seb_main_004.whosbook.curation.entity.Curation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CurationRepository extends JpaRepository<Curation, Long> {
 
     Curation findByCurationId(long curationId);
+
+    Page<Curation> findByCurationStatusAndVisibility(Curation.CurationStatus curationStatus, Curation.Visibility visibility, Pageable pageable);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -9,6 +9,9 @@ import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.repository.MemberRepository;
 import com.seb_main_004.whosbook.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
@@ -74,6 +77,14 @@ public class CurationService {
         }
 
         return curation;
+    }
+
+    public Page<Curation> getNewCurations(int page, int size){
+        // 추후 리팩토링 필요
+        return curationRepository.findByCurationStatusAndVisibility(
+                Curation.CurationStatus.CURATION_ACTIVE,
+                Curation.Visibility.PUBLIC,
+                PageRequest.of(page, size, Sort.by("curationId").descending()));
     }
 
     public Curation findVerifiedCurationById(long curationId) {


### PR DESCRIPTION
## 개요
- NEW 큐레이션 리스트 조회 API

## 작업사항
- `/curations/new?page={page}&size={size}` url을 통해 최신순으로 정렬된 큐레이션 리스트 조회 가능

### 참고사항
- 카테고리 기능이 추가 되는 것 그리고 성능 개선 면에서 추후 리팩토링이 필요할 것 같습니다

### 스크린샷
- gif, 이미지 파일 등

## 리뷰 요청사항
- 문제 될 부분이나 개선 사항이 필요한 것 리뷰 부탁드립니다!