### PR TITLE
Feat: Member도메인 페이지네이션 리팩토링

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationMultiResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationMultiResponseDto.java
@@ -2,11 +2,14 @@ package com.seb_main_004.whosbook.curation.dto;
 
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import com.seb_main_004.whosbook.member.dto.CuratorResponseDto;
+import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 //회원 마이페이지의 '내가 쓴 큐레이션 목록' API를 위한 DTO
+
+@Builder
 @Data
 public class CurationMultiResponseDto {
     //기존 CurationSingleDetailResponseDto와의 차이점은 'private CuratorResponseDto curator'변수가 'private long memberId'로 변경됨

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -1,6 +1,7 @@
 package com.seb_main_004.whosbook.curation.mapper;
 
 import com.seb_main_004.whosbook.curation.dto.CurationListResponseDto;
+import com.seb_main_004.whosbook.curation.dto.CurationMultiResponseDto;
 import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
 import com.seb_main_004.whosbook.curation.dto.CurationSingleDetailResponseDto;
 import com.seb_main_004.whosbook.curation.entity.Curation;
@@ -53,9 +54,28 @@ public interface CurationMapper {
                 .collect(Collectors.toList());
     }
 
+    default List<CurationMultiResponseDto> curationsToCurationMultiListResponseDtos(List<Curation> curations){
+        return curations.stream()
+                .map(curation -> curationToCurationMultiResponseDto(curation))
+                .collect(Collectors.toList());
+    }
+
     default CurationListResponseDto curationToCurationListResponseDto(Curation curation){
         return CurationListResponseDto.builder()
                 .curator(memberToCuratorResponseDto(curation.getMember()))
+                .like(15)
+                .curationId(curation.getCurationId())
+                .emoji(curation.getEmoji())
+                .title(curation.getTitle())
+                .content(curation.getContent())
+                .createdAt(curation.getCreatedAt())
+                .updatedAt(curation.getUpdatedAt())
+                .build();
+    }
+
+    default CurationMultiResponseDto curationToCurationMultiResponseDto(Curation curation){
+        return CurationMultiResponseDto.builder()
+                .memberId(curation.getMember().getMemberId())
                 .like(15)
                 .curationId(curation.getCurationId())
                 .emoji(curation.getEmoji())

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
@@ -1,17 +1,16 @@
 package com.seb_main_004.whosbook.curation.repository;
 
 import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface CurationRepository extends JpaRepository<Curation, Long> {
 
     Curation findByCurationId(long curationId);
 
     Page<Curation> findByCurationStatusAndVisibility(Curation.CurationStatus curationStatus, Curation.Visibility visibility, Pageable pageable);
+
+    Page<Curation> findByMemberAndCurationStatus(Member member, Curation.CurationStatus curationStatus, Pageable pageable);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -86,10 +86,15 @@ public class CurationService {
 
     //내가 쓴 큐레이션 목록 조회
     public Page<Curation> getMyCurations(int page, int size, Member member) {
-        return curationRepository.findByMemberAndCurationStatus(
+        Page<Curation> myCurations = curationRepository.findByMemberAndCurationStatus(
                 member,
                 Curation.CurationStatus.CURATION_ACTIVE,
                 PageRequest.of(page, size));
+
+        if(myCurations.getContent().size() == 0)
+            throw new BusinessLogicException(ExceptionCode.CURATION_NOT_POST);
+
+        return myCurations;
     }
 
     public Curation findVerifiedCurationById(long curationId) {

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -6,16 +6,13 @@ import com.seb_main_004.whosbook.curation.repository.CurationRepository;
 import com.seb_main_004.whosbook.exception.BusinessLogicException;
 import com.seb_main_004.whosbook.exception.ExceptionCode;
 import com.seb_main_004.whosbook.member.entity.Member;
-import com.seb_main_004.whosbook.member.repository.MemberRepository;
 import com.seb_main_004.whosbook.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -85,6 +82,14 @@ public class CurationService {
                 Curation.CurationStatus.CURATION_ACTIVE,
                 Curation.Visibility.PUBLIC,
                 PageRequest.of(page, size, Sort.by("curationId").descending()));
+    }
+
+    //내가 쓴 큐레이션 목록 조회
+    public Page<Curation> getMyCurations(int page, int size, Member member) {
+        return curationRepository.findByMemberAndCurationStatus(
+                member,
+                Curation.CurationStatus.CURATION_ACTIVE,
+                PageRequest.of(page, size));
     }
 
     public Curation findVerifiedCurationById(long curationId) {

--- a/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
@@ -12,6 +12,7 @@ public enum ExceptionCode {
     MEMBER_DOES_NOT_MATCH(403,"사용자가 맞지 않습니다."),
     INVALID_MEMBER_STATUS(400,"잘못된 사용자 상태입니다."),
     CURATION_NOT_FOUND(404,"큐레이션을 찾을 수 없습니다."),
+    CURATION_NOT_POST(404,"작성한 큐레이션이 없습니다."),
     CURATION_ACCESS_DENIED(403,"큐레이션을 열람 할 수 없습니다."),
     CURATION_CANNOT_CHANGE(403,"큐레이션을 수정 할 수 없습니다."),
     CURATION_CANNOT_DELETE(403,"큐레이션을 삭제 할 수 없습니다."),

--- a/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
@@ -1,5 +1,8 @@
 package com.seb_main_004.whosbook.member.controller;
 
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import com.seb_main_004.whosbook.curation.mapper.CurationMapper;
+import com.seb_main_004.whosbook.curation.service.CurationService;
 import com.seb_main_004.whosbook.member.dto.MemberPatchDto;
 import com.seb_main_004.whosbook.member.dto.MemberPostDto;
 import com.seb_main_004.whosbook.dto.MultiResponseDto;
@@ -25,10 +28,16 @@ import java.util.List;
 public class MemberController {
     private final MemberService memberService;
     private final MemberMapper memberMapper;
+    private final CurationService curationService;
+    private final CurationMapper curationMapper;
 
-    public MemberController(MemberService memberService, MemberMapper memberMapper) {
+
+    public MemberController(MemberService memberService, MemberMapper memberMapper,
+                            CurationService curationService, CurationMapper curationMapper) {
         this.memberService = memberService;
         this.memberMapper = memberMapper;
+        this.curationService = curationService;
+        this.curationMapper = curationMapper;
     }
 
     @PostMapping
@@ -58,10 +67,15 @@ public class MemberController {
 
     //내가 작성한 큐레이션 리스트 조회
     @GetMapping("/curations")
-    public ResponseEntity getMyCurations() {
-        Member response = memberService.findMember(getAuthenticatedEmail());
+    public ResponseEntity getMyCurations(@Positive @RequestParam("page") int page,
+                                          @Positive @RequestParam("size") int size) {
+        Member member = memberService.findMember(getAuthenticatedEmail());
+        Page<Curation> curationPage = curationService.getMyCurations(page-1, size, member);
+        List<Curation> curations = curationPage.getContent();
 
-        return new ResponseEntity(memberMapper.memberToMemberAndCurationResponseDto(response), HttpStatus.OK);
+        return new ResponseEntity(new MultiResponseDto<>(
+                curationMapper.curationsToCurationMultiListResponseDtos(curations), curationPage),
+                HttpStatus.OK);
     }
 
     //내가 구독한 큐레이터 리스트 조회

--- a/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapper.java
@@ -37,45 +37,5 @@ public interface MemberMapper {
         }
     }
 
-    //회원 마이페이지의 '내가 쓴 큐레이션 목록' API를 위한 매퍼 메소드
-    //기본적으론 Entity->Dto 매핑과 유사하지만 '내가 쓴 큐레이션'리스트를 매핑하는 과정이 복잡하여 직접 구현
-    //추후 빌더패턴을 적용하여 리팩토링 예정
-    default MemberAndCurationResponseDto memberToMemberAndCurationResponseDto(Member member) {
-        MemberAndCurationResponseDto memberAndCurationResponseDto = new MemberAndCurationResponseDto();
-        memberAndCurationResponseDto.setMemberId(member.getMemberId());
-        memberAndCurationResponseDto.setEmail(member.getEmail());
-        memberAndCurationResponseDto.setNickname(member.getNickname());
-        memberAndCurationResponseDto.setIntroduction(member.getIntroduction());
-        //    회원가입 시 이미지 업로드를 위한 변수로서, 추후 구현
-        //    memberAndCurationResponseDto.setImage(member.getImage());
-        memberAndCurationResponseDto.setMemberStatus(member.getMemberStatus());
-
-        //'내가 쓴 큐레이션'리스트 매핑
-        ListIterator<Curation> curations = member.getCurations().listIterator();
-
-        if(curations == null) {
-            memberAndCurationResponseDto.setCurations(null);
-        } else {
-            List<CurationMultiResponseDto> curationResponseDtos = new ArrayList<>(member.getCurations().size());
-
-            while(curations.hasNext()) {
-                Curation curation = curations.next();
-                CurationMultiResponseDto curationMultiResponseDto = new CurationMultiResponseDto();
-                curationMultiResponseDto.setMemberId(curation.getMember().getMemberId());
-                curationMultiResponseDto.setLike(100); //좋아요는 더미데이터로 100으로 설정, 좋아요 기능 구현 후 리팩토링 예정
-                curationMultiResponseDto.setCurationId(curation.getCurationId());
-                curationMultiResponseDto.setEmoji(curation.getEmoji());
-                curationMultiResponseDto.setTitle(curation.getTitle());
-                curationMultiResponseDto.setContent(curation.getContent());
-                curationMultiResponseDto.setVisibility(curation.getVisibility());
-                curationMultiResponseDto.setCreatedAt(curation.getCreatedAt());
-                curationMultiResponseDto.setUpdatedAt(curation.getUpdatedAt());
-                curationResponseDtos.add(curationMultiResponseDto);
-            }
-            memberAndCurationResponseDto.setCurations(curationResponseDtos);
-        }
-        return memberAndCurationResponseDto;
-    }
-
     MemberResponseDto memberToMemberResponseDto(Member member);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
@@ -89,7 +89,12 @@ public class MemberService {
             Member subscribingMember = subscribe.getSubscribedMember();
             subscribingMembers.add(subscribingMember);
         }
-        return new PageImpl(subscribingMembers, PageRequest.of(page, size), subscribingMembers.size());
+
+        int offset = page * size;
+        int toIndex = Math.min(offset+size, subscribingMembers.size());
+        List<Member> pageContent = subscribingMembers.subList(offset, toIndex);
+
+        return new PageImpl<>(pageContent, PageRequest.of(page, size), subscribingMembers.size());
     }
 
     public void deleteMember(String authenticatedEmail) {


### PR DESCRIPTION
## 개요
- 멤버 도메인 페이지네이션 기능 관련 리팩토링

## 작업사항
- getMyCurations(내가 작성한 큐레이션 목록 조회) 페이지네이션 구현
- getMyMembers(내가 구독한 큐레이터 목록 조회) 페이지네이션 리팩토링

### 참고사항
- getMyCurations 페이지네이션을 구현하며, 기존의 복잡했던 코딩을 보다 직관적으로 리팩토링했습니다.
- getMyMembers 페이지네이션 기능 '현재 페이지 조회'에서 오류가 발생하여, 해당 오류를 해결하는 리팩토링 진행했습니다.
- 로컬테스트 완료
## 리뷰 요청사항
- 참고사항의 이외에 추가로 예외 처리가 필요한 부분이나, 궁금한 점이 있다면 피드백 주시기 바랍니다.