### PR TITLE
feat: 타 유저가 작성한 큐레이션 목록 조회 API

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -84,6 +84,7 @@ public interface CurationMapper {
                 .emoji(curation.getEmoji())
                 .title(curation.getTitle())
                 .content(curation.getContent())
+                .visibility(curation.getVisibility())
                 .createdAt(curation.getCreatedAt())
                 .updatedAt(curation.getUpdatedAt())
                 .build();

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
@@ -13,4 +13,6 @@ public interface CurationRepository extends JpaRepository<Curation, Long> {
     Page<Curation> findByCurationStatusAndVisibility(Curation.CurationStatus curationStatus, Curation.Visibility visibility, Pageable pageable);
 
     Page<Curation> findByMemberAndCurationStatus(Member member, Curation.CurationStatus curationStatus, Pageable pageable);
+
+    Page<Curation> findByMemberAndCurationStatusAndVisibility(Member member, Curation.CurationStatus curationStatus, Curation.Visibility visibility, Pageable pageable);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -127,6 +127,20 @@ public class CurationService {
         return myCurations;
     }
 
+    //타 유저가 쓴 큐레이션 목록 조회
+    public Page<Curation> getOtherMemberCurations(int page, int size, Member member) {
+        Page<Curation> myCurations = curationRepository.findByMemberAndCurationStatusAndVisibility(
+                member,
+                Curation.CurationStatus.CURATION_ACTIVE,
+                Curation.Visibility.PUBLIC,
+                PageRequest.of(page, size));
+
+        if(myCurations.getContent().size() == 0)
+            throw new BusinessLogicException(ExceptionCode.CURATION_NOT_POST);
+
+        return myCurations;
+    }
+
     public Curation findVerifiedCurationById(long curationId) {
         Optional<Curation> optionalCuration = curationRepository.findById(curationId);
         return optionalCuration.orElseThrow(

--- a/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
@@ -20,7 +20,6 @@ public enum ExceptionCode {
     REPLY_NOT_FOUND(404,"댓글을 찾을 수 없습니다."),
     REPLY_CANNOT_CHANGE(403,"댓글을 수정 할 수 없습니다."),
     REPLY_CANNOT_DELETE(403,"댓글을 삭제 할 수 없습니다."),
-    SUBSCRIBE_NOT_FOUND(404, "구독정보를 찾을 수 없습니다."),
     SUBSCRIBE_HAS_BEEN_ACTIVE(409, "이미 구독 중 입니다."),
     SUBSCRIBE_HAS_BEEN_NON_ACTIVE(404, "이미 구독취소 상태 입니다."),
     FILE_EXTENSION_NOT_ACCEPTABLE(406, "이미지 확장자만 등록 가능합니다."),

--- a/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
@@ -67,6 +67,8 @@ public class MemberService {
         return memberRepository.save(findMember);
     }
 
+    //멤버도메인 우선 리팩토링 로직
+    //쿼리문 개선으로 페이징 처리된 멤버리스트를 가져오도록 리팩토링 해야함
     public Member findVerifiedMemberByEmail(String email){
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
         if(optionalMember.isEmpty() || optionalMember.get().getMemberStatus()== Member.MemberStatus.MEMBER_DELETE) {
@@ -88,9 +90,6 @@ public class MemberService {
         List<Member> subscribingMembers = new ArrayList<>();
 
         for(Subscribe subscribe : subscribes) {
-            // 구독취소 상태이면 저장하지 않는다.
-            if(subscribe.getSubscribeStatus()== Subscribe.SubscribeStatus.SUBSCRIBE_NON_ACTIVE) continue;
-
             Member subscribingMember = subscribe.getSubscribedMember();
             subscribingMembers.add(subscribingMember);
         }
@@ -104,11 +103,9 @@ public class MemberService {
 
     public boolean findIsSubscribed(String authenticatedEmail, Member otherMember) {
         Optional<Subscribe> optionalSubscribe = subscribeRepository.findBySubscriberAndSubscribedMember(findVerifiedMemberByEmail(authenticatedEmail), otherMember);
-        if(optionalSubscribe.isPresent()) {
-            return true;
-        } else {
-            return false;
-        }
+        if(optionalSubscribe.isPresent()) return true;
+
+        return false;
     }
 
     public void deleteMember(String authenticatedEmail) {

--- a/server/src/main/java/com/seb_main_004/whosbook/subscribe/entity/Subscribe.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/subscribe/entity/Subscribe.java
@@ -14,10 +14,6 @@ public class Subscribe {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long subscribeId;
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false)
-    private SubscribeStatus subscribeStatus = SubscribeStatus.SUBSCRIBE_NON_ACTIVE;
-
     // 구독자(구독한 유저)
     @JoinColumn(name = "subscriber")
     @ManyToOne
@@ -27,19 +23,4 @@ public class Subscribe {
     @JoinColumn(name = "subscribedMember")
     @ManyToOne
     private Member subscribedMember;
-
-    @Getter
-    public enum SubscribeStatus{
-
-        SUBSCRIBE_ACTIVE("구독중"),
-        SUBSCRIBE_NON_ACTIVE("구독취소");
-
-        @Getter
-        @Setter
-        private String status;
-
-        SubscribeStatus(String status) {
-            this.status = status;
-        }
-    }
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/subscribe/service/SubscribeService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/subscribe/service/SubscribeService.java
@@ -28,33 +28,23 @@ public class SubscribeService {
         Subscribe subscribe = new Subscribe();
         Optional<Subscribe> optionalSubscribe = subscribeRepository.findBySubscriberAndSubscribedMember(subscriber, subscribingMember);
 
-        if (optionalSubscribe.isPresent()) {
-            subscribe = optionalSubscribe.get();
+        if (optionalSubscribe.isPresent())
+            throw new BusinessLogicException(ExceptionCode.SUBSCRIBE_HAS_BEEN_ACTIVE);
 
-            if(subscribe.getSubscribeStatus() == Subscribe.SubscribeStatus.SUBSCRIBE_ACTIVE){
-                throw new BusinessLogicException(ExceptionCode.SUBSCRIBE_HAS_BEEN_ACTIVE);
-            }
-        } else {
-            subscribe.setSubscriber(subscriber);
-            subscribe.setSubscribedMember(subscribingMember);
-        }
+        subscribe.setSubscriber(subscriber);
+        subscribe.setSubscribedMember(subscribingMember);
 
-        subscribe.setSubscribeStatus(Subscribe.SubscribeStatus.SUBSCRIBE_ACTIVE);
         subscribeRepository.save(subscribe);
     }
 
     public void deleteSubscribe(long subscribedMemberId, String authenticatedEmail) {
         Member subscriber = findVerifiedMemberByEmail(authenticatedEmail);
         Member subscribingMember = findVerifiedMemberByMemberId(subscribedMemberId);
+
         Optional<Subscribe> optionalSubscribe = subscribeRepository.findBySubscriberAndSubscribedMember(subscriber, subscribingMember);
-        Subscribe subscribe= optionalSubscribe.orElseThrow(()-> new BusinessLogicException(ExceptionCode.SUBSCRIBE_NOT_FOUND));
+        Subscribe subscribe= optionalSubscribe.orElseThrow(()-> new BusinessLogicException(ExceptionCode.SUBSCRIBE_HAS_BEEN_NON_ACTIVE));
 
-
-        if(subscribe.getSubscribeStatus() == Subscribe.SubscribeStatus.SUBSCRIBE_NON_ACTIVE)
-            throw new BusinessLogicException(ExceptionCode.SUBSCRIBE_HAS_BEEN_NON_ACTIVE);
-
-        subscribe.setSubscribeStatus(Subscribe.SubscribeStatus.SUBSCRIBE_NON_ACTIVE);
-        subscribeRepository.save(subscribe);
+        subscribeRepository.delete(subscribe);
     }
 
     public Member findVerifiedMemberByEmail(String email){


### PR DESCRIPTION
## 개요
- 타 유저가 작성한 큐레이션 목록 조회 API구현
- Subscribe 리팩토링

## 작업사항
- 타 유저가 작성한 큐레이션 목록 조회 API구현
- Subscribe 리팩토링
  --> 기존의 Subscribe 도메인은 post, delete 동작 시 status를 변경하는 방식으로 동작하였음
  --> 이를 테이블을 생성하고 삭제하는 방식으로 변경함 (데이터베이스 리소스 절약과, 매핑작업의 간결화 등의 이유)

### 참고사항
- 로컬테스트 완료

## 리뷰 요청사항
- 개선해야 할 부분이나 궁금한 점이 있다면, 코멘트 남겨주십시오.