### PR TITLE
[Client] 큐레이션 공개/비공개 기능 구현

### DIFF
--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -68,7 +68,7 @@ const CurationDetailPage = () => {
       navigate('/');
     } catch (error) {
       console.error(error);
-      alert('삭제할 글을 찾을 수 없어요.');
+      alert('큐레이션을 찾을 수 없어요 😔');
     }
   };
   
@@ -86,6 +86,9 @@ const CurationDetailPage = () => {
           alert('이 큐레이션은 이미 삭제되었어요 🫥');
           navigate('/');
           // TODO: 404 에러 페이지로 연결 예정
+        } else if ((error as AxiosError)?.response?.status === 403) {
+          alert('비밀 글로 작성된 큐레이션 이에요 🔒');
+          navigate('/');
         }
       }
     };
@@ -99,82 +102,101 @@ const CurationDetailPage = () => {
     }
   }, [curation, navigate]);
 
+  const isAuthor = () => {
+    if (curation && curator) {
+      return curation.curator.memberId === curator.memberId;
+    }
+    return false;
+  };
+
+  if (curation?.visibility === 'SECRET' && !isAuthor()) {
+    return null;
+  }
+
   return (
     <Container>
       <FormContainer>
-      <TitleContainer>
-          {curation?.emoji}
-          <DoubleSpace />
-          {curation?.title}
-          <EditDeleteContainer onClick={handleToggleEditDelete}>
-            <AiOutlineMore />
-            <EditDeleteButton isVisible={isEditDeleteVisible}>
-              <EditButton onClick={handleEdit}>수정하기</EditButton>
-              <DeleteButton onClick={handleDelete}>삭제하기</DeleteButton>
-            </EditDeleteButton>
-          </EditDeleteContainer>
-        </TitleContainer>
-        <GridContainer>
-          <DetailInfoLeft>
-            <CurationDetailInfo />
-          </DetailInfoLeft>
-          <DetailInfoRight>
-            <CurationProfileInfo curator={curator?.nickname} />
-            <CurationCreatedDate createdAt={curation?.createdAt} />
-          </DetailInfoRight>
-        </GridContainer>
-        <ContentContainer>
-          <div dangerouslySetInnerHTML={{ __html: `${curation?.content}` }} />
-        </ContentContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="title" content="추천하는 책" />
-          {/* {curation && <BookInfo book={curation.selectedBook} />} */}
-        </ItemContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="reply" content="댓글 쓰기" />
-          <Input
-            id="title"
-            width="100%"
-            color="#000"
-            value={replyValue}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setReplyValue(e.target.value)}
-          />
-        </ItemContainer>
-        <ButtonContainer>
-          <CancelButton>
-            <Button type="cancel" content="취소" />
-          </CancelButton>
-          <CreateButton>
-            <Button type="primary" content="등록" />
-          </CreateButton>
-        </ButtonContainer>
-        <ItemContainer>
-          <Label type="title" htmlFor="replycount" content= "댓글 2개" />
-          <CommentContainer>
-            <ReplyProfileInfo/>
-              어쿠스틱과 일렉트로닉, 클래식과 팝 음악의 경계에서 완벽하게 자유로웠던 우리 시대 최고의 마에스트로 최고다!!~~~
-            <ReplyCreatedDate/>
-          </CommentContainer>
-          <CommentContainer>
-            <ReplyProfileInfo/>
-              그가 삶의 마지막 고비에서 되돌아본 인생과 예술, 우정과 사랑, 자연과 철학, 그리고 시간을 뛰어넘는다.
-              그가 삶의 마지막 고비에서 되돌아본 인생과 예술, 우정과 사랑, 자연과 철학, 그리고 시간을 뛰어넘는다.
-              그가 삶의 마지막 고비에서 되돌아본 인생과 예술, 우정과 사랑, 자연과 철학, 그리고 시간을 뛰어넘는다.
-            <ReplyCreatedDate/>
-          </CommentContainer>
-        </ItemContainer>
-        <ButtonContainer>
-          <DetailButton>
-            <Button type="detail" content="더보기" />
-          </DetailButton>
-        </ButtonContainer>
+        {curation && (
+          <>
+            <TitleContainer>
+              {curation.emoji}
+              <DoubleSpace />
+              {curation.title}
+              {isAuthor() && (
+                <EditDeleteContainer onClick={handleToggleEditDelete}>
+                  <AiOutlineMore />
+                  {isEditDeleteVisible && (
+                    <EditDeleteButton isVisible={isEditDeleteVisible}>
+                      <EditButton onClick={handleEdit}>수정하기</EditButton>
+                      <DeleteButton onClick={handleDelete}>삭제하기</DeleteButton>
+                    </EditDeleteButton>
+                  )}
+                </EditDeleteContainer>
+              )}
+            </TitleContainer>
+            <GridContainer>
+              <DetailInfoLeft>
+                <CurationDetailInfo />
+              </DetailInfoLeft>
+              <DetailInfoRight>
+                <CurationProfileInfo curator={curator?.nickname} />
+                <CurationCreatedDate createdAt={curation.createdAt} />
+                {/* TODO: createdAt 업로드 일자로 반영 */}
+              </DetailInfoRight>
+            </GridContainer>
+            <ContentContainer>
+              <div dangerouslySetInnerHTML={{ __html: `${curation.content}` }} />
+            </ContentContainer>
+            <ItemContainer>
+              <Label type="title" htmlFor="title" content="추천하는 책" />
+              {/* {curation && <BookInfo book={curation.selectedBook} />} */}
+            </ItemContainer>
+            <ItemContainer>
+              <Label type="title" htmlFor="reply" content="댓글 쓰기" />
+              <Input
+                id="title"
+                width="100%"
+                color="#000"
+                value={replyValue}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setReplyValue(e.target.value)}
+              />
+            </ItemContainer>
+            <ButtonContainer>
+              <CancelButton>
+                <Button type="cancel" content="취소" />
+              </CancelButton>
+              <CreateButton>
+                <Button type="primary" content="등록" />
+              </CreateButton>
+            </ButtonContainer>
+            <ItemContainer>
+              <Label type="title" htmlFor="replycount" content="댓글 2개" />
+              <CommentContainer>
+                <ReplyProfileInfo />
+                어쿠스틱과 일렉트로닉, 클래식과 팝 음악의 경계에서 완벽하게 자유로웠던 우리 시대 최고의 마에스트로 최고다!!~~~
+                <ReplyCreatedDate />
+              </CommentContainer>
+              <CommentContainer>
+                <ReplyProfileInfo />
+                그가 삶의 마지막 고비에서 되돌아본 인생과 예술, 우정과 사랑, 자연과 철학, 그리고 시간을 뛰어넘는다.
+                그가 삶의 마지막 고비에서 되돌아본 인생과 예술, 우정과 사랑, 자연과 철학, 그리고 시간을 뛰어넘는다.
+                그가 삶의 마지막 고비에서 되돌아본 인생과 예술, 우정과 사랑, 자연과 철학, 그리고 시간을 뛰어넘는다.
+                <ReplyCreatedDate />
+              </CommentContainer>
+            </ItemContainer>
+            <ButtonContainer>
+              <DetailButton>
+                <Button type="detail" content="더보기" />
+              </DetailButton>
+            </ButtonContainer>
+          </>
+        )}
       </FormContainer>
     </Container>
   );
 };
 
 export default CurationDetailPage;
-
 
 const Container = styled.div`
   display: flex;

--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -289,6 +289,10 @@ const ContentContainer = styled.div`
   text-align: left;
   font-size: 1.2rem;
   line-height: 2rem;
+  img {
+    max-width: 100%;
+    height: auto;
+  }
 `;
 
 const ItemContainer = tw.div`

--- a/client/src/pages/Curation/CurationEditPage.tsx
+++ b/client/src/pages/Curation/CurationEditPage.tsx
@@ -144,6 +144,7 @@ const CurationEditPage = () => {
     setList([]);
     setBook(null);
     handleModal();
+    navigate(-1); 
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -270,7 +271,7 @@ const CurationEditPage = () => {
           </ItemContainer>
           <ButtonContainer>
             <CancelButton>
-              <Button type="cancel" content="취소" />
+              <Button type="cancel" content="취소" onClick={handleCancel} />
             </CancelButton>
             <PrimaryButton>
               <Button type="primary" content="발행" onClick={handleEdit} />

--- a/client/src/pages/Curation/CurationEditPage.tsx
+++ b/client/src/pages/Curation/CurationEditPage.tsx
@@ -58,9 +58,10 @@ export interface Curator {
 
 const CurationEditPage = () => {
   const [curation, setCuration] = useState<Curation>();
-  const [emojiValue, setEmojiValue] = useState(curation?.emoji); 
   const [titleValue, setTitleValue] = useState(curation?.title); 
+  const [emojiValue, setEmojiValue] = useState(curation?.emoji);
   const [contentValue, setContentValue] = useState(curation?.content);
+  const [imageIds, setImageIds] = useState<string[]>([]);
   const [visibilityValue, setVisibilityValue] = useState(curation?.visibility);
   const [isModal, setIsModal] = useState<boolean>(false);
   const [title, setTitle] = useState<string>('');
@@ -105,6 +106,7 @@ const CurationEditPage = () => {
         setEmojiValue(curation?.emoji)
         setTitleValue(curation?.title)
         setContentValue(curation?.content)
+        setImageIds(curationData.imageIds);
         setVisibilityValue(curation?.visibility)
       } catch (error) {
         console.error(error);
@@ -121,7 +123,8 @@ const CurationEditPage = () => {
           title: titleValue,
           emoji: emojiValue,
           content: contentValue,
-          visibility: 'PUBLIC'
+          visibility: visibilityValue,
+          imageIds: imageIds 
         });
         console.log(response.data);
         navigate(`/curations/${curationId}`);
@@ -246,22 +249,24 @@ const CurationEditPage = () => {
             <Label type="title" htmlFor="title" content="큐레이션 공개 여부" />
             <RadioButtonContainer>
             <input
-              type="radio"
-              id="select"
-              name="radio"
-              checked={visibilityValue === 'PUBLIC'}
-              onChange={() => setVisibilityValue('PUBLIC')}
-            />
-            <label htmlFor="select">공개</label>
-            <input
-              type="radio"
-              id="select2"
-              name="radio"
-              checked={visibilityValue === 'SECRET'}
-              onChange={() => setVisibilityValue('SECRET')}
-            />
-            <label htmlFor="select2">비공개</label>
-          </RadioButtonContainer>
+                type="radio"
+                id="public"
+                name="visibility"
+                value="PUBLIC"
+                checked={visibilityValue === 'PUBLIC'}
+                onChange={() => setVisibilityValue('PUBLIC')}
+              />
+              <label htmlFor="public">공개</label>
+              <input
+                type="radio"
+                id="secret"
+                name="visibility"
+                value="SECRET"
+                checked={visibilityValue === 'SECRET'}
+                onChange={() => setVisibilityValue('SECRET')}
+              />
+              <label htmlFor="secret">비공개</label>
+            </RadioButtonContainer>
           </ItemContainer>
           <ButtonContainer>
             <CancelButton>

--- a/client/src/pages/Curation/CurationWritePage.tsx
+++ b/client/src/pages/Curation/CurationWritePage.tsx
@@ -103,6 +103,7 @@ const CurationWritePage = () => {
     setList([]);
     setBook(null);
     handleModal();
+    navigate(-1); 
   };
   
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -229,7 +230,7 @@ const CurationWritePage = () => {
           </ItemContainer>
           <ButtonContainer>
             <CancelButton>
-              <Button type="cancel" content="취소" />
+              <Button type="cancel" content="취소" onClick={handleCancel} />
             </CancelButton>
             <PrimaryButton>
               <Button type="primary" content="발행" onClick={handleCreate} />

--- a/client/src/pages/Curation/CurationWritePage.tsx
+++ b/client/src/pages/Curation/CurationWritePage.tsx
@@ -36,10 +36,11 @@ export interface SelectedBook {
 }
 
 const CurationWritePage = () => {
-  const [contentValue, setContentValue] = useState('');
-  const [emojiValue, setEmojiValue] = useState('');
   const [titleValue, setTitleValue] = useState('');
-  const [visibilityValue] = useState('PUBLIC');
+  const [emojiValue, setEmojiValue] = useState('');
+  const [contentValue, setContentValue] = useState('');
+  const [imageIds] = useState<string[]>([]);
+  const [visibilityValue, setVisibilityValue] = useState('PUBLIC');
   const [isModal, setIsModal] = useState<boolean>(false);
   const [title, setTitle] = useState<string>("");
   const [list, setList] = useState<Book[]>([]);
@@ -80,7 +81,8 @@ const CurationWritePage = () => {
           title: titleValue,
           emoji: emojiValue,
           content: contentValue,
-          visibility: visibilityValue
+          visibility: visibilityValue,
+          imageIds: imageIds
         });
         console.log(response.headers)
         const curationId = response.headers.location;
@@ -106,7 +108,7 @@ const CurationWritePage = () => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
   };
-
+  
   const {VITE_KAKAO_API_KEY} = import.meta.env
 
   const handleSearch = () => {
@@ -205,10 +207,24 @@ const CurationWritePage = () => {
           <ItemContainer>
             <Label type="title" htmlFor="title" content="큐레이션 공개 여부" />
             <RadioButtonContainer>
-              <input type="radio" id="select" name="radio" />
-              <label htmlFor="select">공개</label>
-              <input type="radio" id="select2" name="radio" />
-              <label htmlFor="select2">비공개</label>
+              <input
+                type="radio"
+                id="public"
+                name="visibility"
+                value="PUBLIC"
+                checked={visibilityValue === 'PUBLIC'}
+                onChange={() => setVisibilityValue('PUBLIC')}
+              />
+              <label htmlFor="public">공개</label>
+              <input
+                type="radio"
+                id="secret"
+                name="visibility"
+                value="SECRET"
+                checked={visibilityValue === 'SECRET'}
+                onChange={() => setVisibilityValue('SECRET')}
+              />
+              <label htmlFor="secret">비공개</label>
             </RadioButtonContainer>
           </ItemContainer>
           <ButtonContainer>


### PR DESCRIPTION
## 개요

- 큐레이션 공개/비공개 기능 구현
- 자잘한 기능과 버그 수정

## 작업사항

- 큐레이션 공개 설정 시, 해당 큐레이션이 모든 사용자에게 보여지도록 구현했습니다.
- 큐레이션 비공개 설정 시, 해당 큐레이션이 작성한 본인에게만 보여지도록 구현했습니다.
- 작성자 본인이 아닌 사용자가 비공개 큐레이션 진입 시, 임시로 alert을 띄웠습니다.

## 참고사항

- @Kyunju 님이 구현해 주신 이미지 업로드로 `CurationWritePage`와 `CurationEditPage`에 `imageIds`를 추가했습니다.
- 큐레이션 작성 후 `CurationDetailPage`에 이미지가 container 크기를 벗어나는 경우가 있어, max-width를 제한했습니다.
- `CurationWritePage`와 `CurationEditPage`에서 [취소] 버튼을 누르면 이전 페이지로 이동되도록 구현했습니다.

## 스크린샷
*좌측은 작성자 본인 | 우측은 작성자 제외한 타유저

https://github.com/codestates-seb/seb44_main_004/assets/123397411/d9244a96-c659-4c3c-8b41-bef268059572

## 리뷰 요청사항

- 피드백은 언제나 환영입니다!
