### PR TITLE
feat: 큐레이션 이미지 업로드 유효성 검사 및 수정 기능

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -92,7 +92,7 @@ public class CurationController {
         log.info("# 이미지 확장자 검증 실행");
         ImageStorageUtils.verifyImageExtension(curationImage);
 
-        CurationImage savedImage = curationImageService.uploadCurationImage(curationImage);
+        CurationImage savedImage = curationImageService.uploadCurationImage(curationImage, getAuthenticatedEmail());
 
         return new ResponseEntity(new CurationImageResponseDto(savedImage.getCurationImageId(),
                 savedImage.getPath()), HttpStatus.OK);

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationImageDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationImageDto.java
@@ -1,0 +1,8 @@
+package com.seb_main_004.whosbook.curation.dto;
+
+import java.util.List;
+
+public interface CurationImageDto {
+    List<Long> getImageIds();
+    String getContent();
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
@@ -8,19 +8,22 @@ import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Builder
 @Getter
 public class CurationPatchDto {
-    @NotBlank
-    @Length(max = 5)
+    @NotBlank(message = "이모지를 입력해주세요")
+    @Length(max = 5, message = "최대 5개의 이모지만 등록이 가능합니다.")
     private String emoji;
-    @NotBlank
-    @Length(min = 1, max = 30)
+    @NotBlank(message = "제목을 입력해주세요")
+    @Length(min = 1, max = 30, message = "제목은 최소 1글자 이상 최대 30글자 미만으로 작성해주세요")
     private String title;
-    @NotBlank
-    @Length(min = 10)
+    @NotBlank(message = "내용을 입력해주세요")
+    @Length(min = 10, message = "내용은 최소 10글자 이상 작성해주세요")
     private String content;
-    @NotNull
+    @NotNull(message = "공개/비공개 여부를 확인해주세요")
     private Curation.Visibility visibility;
+    @NotNull(message = "이미지 ID 필드가 존재하지 않습니다.")
+    private List<Long> imageIds;
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
@@ -1,7 +1,6 @@
 package com.seb_main_004.whosbook.curation.dto;
 
 import com.seb_main_004.whosbook.curation.entity.Curation;
-import com.seb_main_004.whosbook.vaildator.NotSpace;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
@@ -12,7 +11,7 @@ import java.util.List;
 
 @Builder
 @Getter
-public class CurationPatchDto {
+public class CurationPatchDto implements CurationImageDto{
     @NotBlank(message = "이모지를 입력해주세요")
     @Length(max = 5, message = "최대 5개의 이모지만 등록이 가능합니다.")
     private String emoji;

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
@@ -4,16 +4,14 @@ import com.seb_main_004.whosbook.curation.entity.Curation;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
 import java.util.List;
 
 @Builder
 @Getter
-public class CurationPostDto {
+public class CurationPostDto implements CurationImageDto{
 
     @NotBlank(message = "이모지를 입력해주세요")
     @Length(max = 5, message = "최대 5개의 이모지만 등록이 가능합니다.")

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
@@ -15,17 +15,17 @@ import java.util.List;
 @Getter
 public class CurationPostDto {
 
-    @NotBlank
-    @Length(max = 5)
+    @NotBlank(message = "이모지를 입력해주세요")
+    @Length(max = 5, message = "최대 5개의 이모지만 등록이 가능합니다.")
     private String emoji;
-    @NotBlank
-    @Length(min = 1, max = 30)
+    @NotBlank(message = "제목을 입력해주세요")
+    @Length(min = 1, max = 30, message = "제목은 최소 1글자 이상 최대 30글자 미만으로 작성해주세요")
     private String title;
-    @NotBlank
-    @Length(min = 10)
+    @NotBlank(message = "내용을 입력해주세요")
+    @Length(min = 10, message = "내용은 최소 10글자 이상 작성해주세요")
     private String content;
-    @NotNull
+    @NotNull(message = "공개/비공개 여부를 확인해주세요")
     private Curation.Visibility visibility;
-    @Nullable
+    @NotNull(message = "이미지 ID 필드가 존재하지 않습니다.")
     private List<Long> imageIds;
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -39,10 +40,10 @@ public class Curation {
     private Member member;
 
     @OneToMany(mappedBy = "curation", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    private List<Reply> replies;
+    private List<Reply> replies = new ArrayList<>();
 
     @OneToMany(mappedBy = "curation", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-    private List<CurationSaveImage> curationSaveImages;
+    private List<CurationSaveImage> curationSaveImages = new ArrayList<>();
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationSaveImageRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationSaveImageRepository.java
@@ -1,7 +1,11 @@
 package com.seb_main_004.whosbook.curation.repository;
 
+import com.seb_main_004.whosbook.curation.entity.CurationImage;
 import com.seb_main_004.whosbook.curation.entity.CurationSaveImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CurationSaveImageRepository extends JpaRepository<CurationSaveImage, Long> {
+    Optional<CurationSaveImage> findByCurationImage(CurationImage curationImage);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationImageService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationImageService.java
@@ -1,9 +1,9 @@
 package com.seb_main_004.whosbook.curation.service;
 
-import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
+import com.seb_main_004.whosbook.curation.dto.CurationImageDto;
 import com.seb_main_004.whosbook.curation.entity.CurationImage;
-import com.seb_main_004.whosbook.curation.entity.CurationSaveImage;
 import com.seb_main_004.whosbook.curation.repository.CurationImageRepository;
+import com.seb_main_004.whosbook.curation.repository.CurationSaveImageRepository;
 import com.seb_main_004.whosbook.exception.BusinessLogicException;
 import com.seb_main_004.whosbook.exception.ExceptionCode;
 import com.seb_main_004.whosbook.image.service.StorageService;
@@ -25,6 +25,7 @@ import java.util.Optional;
 @Transactional
 public class CurationImageService {
     private final CurationImageRepository curationImageRepository;
+    private final CurationSaveImageRepository curationSaveImageRepository;
     private final StorageService storageService;
     private final MemberService memberService;
     private final static String CURATION_IMAGE_PATH = "curationImages";
@@ -60,9 +61,9 @@ public class CurationImageService {
        );
     }
 
-    public List<CurationImage> verifyCurationSaveImages(CurationPostDto postDto, long authenticatedMemberId) {
-        List<Long> curationImageIds = postDto.getImageIds();
-        String content = postDto.getContent();
+    public List<CurationImage> verifyCurationSaveImages(CurationImageDto curationDto, long authenticatedMemberId) {
+        List<Long> curationImageIds = curationDto.getImageIds();
+        String content = curationDto.getContent();
 
         List<CurationImage> curationImages = new ArrayList<>();
 
@@ -74,6 +75,10 @@ public class CurationImageService {
             if (content.contains(curationImage.getImageKey())){
                curationImages.add(curationImage);
             } else {
+                // 큐레이션과 연결된 이미지 연결고리 삭제
+                curationSaveImageRepository.findByCurationImage(curationImage)
+                        .ifPresent(curationSaveImage -> curationSaveImageRepository.delete(curationSaveImage));
+
                 deleteCurationImage(curationImageId);
             }
 

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationImageService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationImageService.java
@@ -7,6 +7,8 @@ import com.seb_main_004.whosbook.curation.repository.CurationImageRepository;
 import com.seb_main_004.whosbook.exception.BusinessLogicException;
 import com.seb_main_004.whosbook.exception.ExceptionCode;
 import com.seb_main_004.whosbook.image.service.StorageService;
+import com.seb_main_004.whosbook.member.entity.Member;
+import com.seb_main_004.whosbook.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,17 +26,19 @@ import java.util.Optional;
 public class CurationImageService {
     private final CurationImageRepository curationImageRepository;
     private final StorageService storageService;
+    private final MemberService memberService;
     private final static String CURATION_IMAGE_PATH = "curationImages";
-
     // 이미지 등록
-    public CurationImage uploadCurationImage(MultipartFile image){
+    public CurationImage uploadCurationImage(MultipartFile image, String authenticatedEmail){
 
+        Member member = memberService.findVerifiedMemberByEmail(authenticatedEmail);
 
-        String key = storageService.makeObjectKey(image, CURATION_IMAGE_PATH);
-        String imagePath = storageService.store(image, CURATION_IMAGE_PATH);
+        String imageKey = storageService.makeObjectKey(image, CURATION_IMAGE_PATH, member.getMemberId());
+        String imagePath = storageService.store(image, imageKey);
 
-        CurationImage curationImage = new CurationImage(key, imagePath);
+        CurationImage curationImage = new CurationImage(imageKey, imagePath);
 
+        log.info("# 저장된 이미지 Owner ID : {}", getImageOwnerId(imageKey));
         log.info("# 이미지 업로드 성공! 업로드 된 이미지 URL : {}", curationImage.getPath());
 
         return curationImageRepository.save(curationImage);
@@ -56,21 +60,35 @@ public class CurationImageService {
        );
     }
 
-    public List<CurationImage> verifyCurationSaveImages(CurationPostDto postDto) {
+    public List<CurationImage> verifyCurationSaveImages(CurationPostDto postDto, long authenticatedMemberId) {
         List<Long> curationImageIds = postDto.getImageIds();
         String content = postDto.getContent();
 
         List<CurationImage> curationImages = new ArrayList<>();
+
         for (long curationImageId : curationImageIds){
+
             CurationImage curationImage = findVerifiedCurationImageById(curationImageId);
+            verifyImageOwner(curationImage, authenticatedMemberId);
+
             if (content.contains(curationImage.getImageKey())){
                curationImages.add(curationImage);
             } else {
                 deleteCurationImage(curationImageId);
             }
+
         }
 
         return curationImages;
+    }
+
+    private void verifyImageOwner(CurationImage curationImage, long authenticatedMemberId){
+        long imageOwnerId = Long.parseLong(getImageOwnerId(curationImage.getImageKey()));
+        if (imageOwnerId != authenticatedMemberId) throw new BusinessLogicException(ExceptionCode.IMAGE_CAN_NOT_SAVE);
+    }
+
+    private String getImageOwnerId(String imageKey) {
+        return imageKey.substring(imageKey.lastIndexOf("/") + 1, imageKey.lastIndexOf("_"));
     }
 
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -39,15 +39,16 @@ public class CurationService {
     @Transactional
     public Curation createCuration(Curation curation, CurationPostDto postDto, String authenticatedEmail){
 
-        curation.setMember(
-                memberService.findVerifiedMemberByEmail(authenticatedEmail));
+        Member member = memberService.findVerifiedMemberByEmail(authenticatedEmail);
+
+        curation.setMember(member);
 
         Curation savedCuration = curationRepository.save(curation);
 
         if (!postDto.getImageIds().isEmpty()){
             log.info("# 포스트 중 삭제된 이미지 없는지 검증실행 ");
 
-            List<CurationImage> curationImages = curationImageService.verifyCurationSaveImages(postDto);
+            List<CurationImage> curationImages = curationImageService.verifyCurationSaveImages(postDto, member.getMemberId());
 
             log.info("# 검증된 이미지와 큐레이션 DB 연결 실행");
             for (CurationImage curationImage : curationImages) {

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -71,6 +71,18 @@ public class CurationService {
 
         findCuration.updateCurationData(patchDto);
 
+        if (!patchDto.getImageIds().isEmpty()){
+            log.info("# 포스트 중 삭제된 이미지 없는지 검증실행 ");
+
+            List<CurationImage> curationImages = curationImageService.verifyCurationSaveImages(patchDto, findCuration.getMember().getMemberId());
+
+            log.info("# 검증된 이미지와 큐레이션 DB 연결 실행");
+            for (CurationImage curationImage : curationImages) {
+                curationSaveImageRepository.save(new CurationSaveImage(findCuration, curationImage));
+                log.info("# 작성된 큐레이션과 이미지 연결 완료!");
+            }
+        }
+
         return curationRepository.save(findCuration);
     }
 

--- a/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
@@ -24,6 +24,7 @@ public enum ExceptionCode {
     SUBSCRIBE_HAS_BEEN_NON_ACTIVE(404, "이미 구독취소 상태 입니다."),
     FILE_EXTENSION_NOT_ACCEPTABLE(415, "이미지 확장자만 등록 가능합니다."),
     IMAGE_NOT_FOUND(404, "이미지를 찾을 수 없습니다."),
+    IMAGE_CAN_NOT_SAVE(403, "이미지를 저장 할 수 있는 권한이 없습니다."),
     IMAGE_UPLOAD_FAILED(500, "파일 업로드에 실패했습니다."),
     NOT_IMPLEMENTATION(501,"Not Implementation");
 

--- a/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/exception/ExceptionCode.java
@@ -23,8 +23,9 @@ public enum ExceptionCode {
     SUBSCRIBE_NOT_FOUND(404, "구독정보를 찾을 수 없습니다."),
     SUBSCRIBE_HAS_BEEN_ACTIVE(409, "이미 구독 중 입니다."),
     SUBSCRIBE_HAS_BEEN_NON_ACTIVE(404, "이미 구독취소 상태 입니다."),
-    FILE_EXTENSION_NOT_ACCEPTABLE(406, "이미지 확장자만 등록 가능합니다."),
+    FILE_EXTENSION_NOT_ACCEPTABLE(415, "이미지 확장자만 등록 가능합니다."),
     IMAGE_NOT_FOUND(404, "이미지를 찾을 수 없습니다."),
+    IMAGE_UPLOAD_FAILED(500, "파일 업로드에 실패했습니다."),
     NOT_IMPLEMENTATION(501,"Not Implementation");
 
     @Getter

--- a/server/src/main/java/com/seb_main_004/whosbook/image/service/S3StorageService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/image/service/S3StorageService.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
+import com.seb_main_004.whosbook.exception.BusinessLogicException;
+import com.seb_main_004.whosbook.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,8 +38,8 @@ public class S3StorageService implements StorageService{
            log.info("# 업로드에 성공했습니다. 이미지 정보 : {}", result.getETag());
 
            return URLDecoder.decode(s3Client.getUrl(bucketName, key).toString(), StandardCharsets.UTF_8);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new BusinessLogicException(ExceptionCode.IMAGE_UPLOAD_FAILED);
         }
     }
 

--- a/server/src/main/java/com/seb_main_004/whosbook/image/service/S3StorageService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/image/service/S3StorageService.java
@@ -51,6 +51,7 @@ public class S3StorageService implements StorageService{
                 .append(memberId)
                 .append("_")
                 .append(System.currentTimeMillis())
+                .append(".")
                 .append(ImageStorageUtils.getFileExtension(file))
                 .toString();
     }

--- a/server/src/main/java/com/seb_main_004/whosbook/image/service/StorageService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/image/service/StorageService.java
@@ -3,7 +3,7 @@ package com.seb_main_004.whosbook.image.service;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface StorageService {
-    String store(MultipartFile file, String imagePath);
-    String makeObjectKey(MultipartFile file, String imagePath);
+    String store(MultipartFile file, String imageKey);
+    String makeObjectKey(MultipartFile multipartFile, String imagePath, long memberId);
     void delete(String imageKey);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/image/utils/ImageStorageUtils.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/image/utils/ImageStorageUtils.java
@@ -21,7 +21,7 @@ public class ImageStorageUtils {
         log.info("# 이미지 확장자 검증 완료 !");
     }
 
-    private static String getFileExtension(MultipartFile file) {
+    public static String getFileExtension(MultipartFile file) {
         String fileName = file.getOriginalFilename();
         return fileName.substring(fileName.lastIndexOf(".") + 1);
     }


### PR DESCRIPTION
## 개요
- 큐레이션 작성시 웹에디터를 통해 이미지 수정 기능을 위한 구현
- Dto 유효성 검사 수정 및 추가

## 작업사항
- 이미지 검증 및 작성 메소드 재사용을 위해 `CurationImageDto` 인터페이스구현 `getContent()`, `getImageIds()` 추가
- `ImageIds` 필드가 존재하지 않으면 유효성 검사에서 에러 나도록 변경
- 이미 큐레이션 작성시 저장한 이미지면 `CurationSaveImage` 테이블을 먼저 삭제 후 이미지 테이블 삭제, S3 스토리지 삭제 순으로 진행
- 본인이 등록한 이미지가 아니면 삭제하거나 등록 할 수 없도록 검증 로직 추가

### 참고사항
- 유효성 검사 메세지가 조금 추가 되었고 메소드 재사용을 위해서 postDto, patchDto 모두 매개변수로 넣기 위해 인터페이스를 구현했습니다.

### 스크린샷
- gif, 이미지 파일 등

## 리뷰 요청사항
- 한번 보시고 수정해야 하거나 리뷰해주실 부분 있으면 말씀해주세요 !