### PR TITLE
fix: 응답데이터 쿼리파람형식으로 변경

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/auth/Oauth/handler/OAuth2MemberSuccessHandler.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/auth/Oauth/handler/OAuth2MemberSuccessHandler.java
@@ -64,11 +64,23 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
             response.setCharacterEncoding("UTF-8");
             response.setContentType("application/json;  charset=UTF-8");
 
-            response.getWriter().write(gson.toJson(responseDto.toString()));
 
-            System.out.println("response후 요청 데이터"+responseDto.toString());
+            MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+            queryParams.add("email", responseDto.getEmail());
+            queryParams.add("nickname", responseDto.getNickname());
+            queryParams.add("imgUrl", responseDto.getImgUrl());
 
-            response.sendRedirect("/register");
+            URI uri= UriComponentsBuilder
+                    .newInstance()
+                    .scheme("http")
+                    .host("localhost")
+                    .port(5173)
+                    .path("register")
+                    .queryParams(queryParams)
+                    .build()
+                    .toUri();
+
+            response.sendRedirect(String.valueOf(uri));
 
 
         }


### PR DESCRIPTION
## 개요
- 소셜로그인시 DB에 회원정보없을때 회원가입페이지로 리다이렉트시키는 부분에서 데이터 형식변경

## 작업사항
-해당 구글데이터를 queryParm형식으로 추가

## 리뷰 요청사항
- 참고사항의 예외 처리 이외에 추가로 예외 처리가 필요한 부분이 있을 지 조언 부탁드립니다.