### PR TITLE
feat:댓글 조회 구현

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/reply/controller/ReplyController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/controller/ReplyController.java
@@ -3,11 +3,13 @@ package com.seb_main_004.whosbook.reply.controller;
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import com.seb_main_004.whosbook.curation.repository.CurationRepository;
 import com.seb_main_004.whosbook.curation.service.CurationService;
+import com.seb_main_004.whosbook.dto.MultiResponseDto;
 import com.seb_main_004.whosbook.reply.dto.ReplyPatchDto;
 import com.seb_main_004.whosbook.reply.dto.ReplyPostDto;
 import com.seb_main_004.whosbook.reply.entity.Reply;
 import com.seb_main_004.whosbook.reply.mapper.ReplyMapper;
 import com.seb_main_004.whosbook.reply.service.ReplyService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.util.List;
 
 @RestController
 @RequestMapping("/curations")
@@ -79,6 +82,25 @@ public class ReplyController {
 
         return  new ResponseEntity(HttpStatus.NO_CONTENT);
 
+
+
+    }
+
+    //댓글조회
+    @GetMapping("replies")
+    public ResponseEntity getReplyList( @Positive @RequestParam("page")int page,
+                                       @Positive @RequestParam("size") int size){
+
+
+        Page<Reply> replyPage= replyService.getReplyList(page-1, size);
+
+        List<Reply> replyList= replyPage.getContent();
+
+        return  new ResponseEntity<>(
+                new MultiResponseDto<>(replyMapper.replyToReplyResponseDto(replyList),
+                        replyPage),
+                HttpStatus.OK
+        );
 
 
     }

--- a/server/src/main/java/com/seb_main_004/whosbook/reply/mapper/ReplyMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/mapper/ReplyMapper.java
@@ -7,6 +7,8 @@ import com.seb_main_004.whosbook.reply.entity.Reply;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface ReplyMapper {
     ReplyPostDto replyToPostDtoToReply(ReplyPostDto replyPostDto);
@@ -15,4 +17,6 @@ public interface ReplyMapper {
     ReplyResponseDto replyToReplyResponseDto(Reply reply);
 
     ReplyPatchDto replyToPatchToReply(ReplyPatchDto replyPatchDto);
+
+    List<ReplyResponseDto> replyToReplyResponseDto(List<Reply> replyList);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/reply/service/ReplyService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/reply/service/ReplyService.java
@@ -10,9 +10,13 @@ import com.seb_main_004.whosbook.reply.dto.ReplyPatchDto;
 import com.seb_main_004.whosbook.reply.dto.ReplyPostDto;
 import com.seb_main_004.whosbook.reply.entity.Reply;
 import com.seb_main_004.whosbook.reply.repository.ReplyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.Positive;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -82,5 +86,11 @@ public class ReplyService {
             throw  new BusinessLogicException(ExceptionCode.MEMBER_DOES_NOT_MATCH);
         }
 
+    }
+
+    public Page<Reply> getReplyList(int page, int size) {
+
+       return  replyRepository.findAll(PageRequest.of(page,size,
+               Sort.by("createdAt").descending()));
     }
 }


### PR DESCRIPTION
## 개요
- 큐레이션 상세조회에서 댓글리스트를 조회할수있다

## 작업사항
- 댓글 조회API추가
- ReplyController,ReplyService,ReplyMapper구현
- 페이지네이션으로구현

### 스크린샷
- 
![image](https://github.com/codestates-seb/seb44_main_004/assets/73240989/c428e172-7279-4415-aecb-1552b5fe346f)

## 리뷰 요청사항
- 참고사항의 예외 처리 이외에 추가로 예외 처리가 필요한 부분이 있을 지 조언 부탁드립니다.