### PR TITLE
fix: 좋아요한 큐레이션 목록조회 API 수정

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -27,8 +28,9 @@ public interface CurationRepository extends JpaRepository<Curation, Long> {
     //멤버가 좋아요한 큐레이션을 불러오는 쿼리문
     @Query(value = "SELECT * FROM Curation c, Member m, Curation_Like l " +
             "WHERE m.member_id = l.member_id AND l.curation_id = c.curation_id " +
-            "And c.curation_status = 'CURATION_ACTIVE' AND c.visibility = 'PUBLIC'", nativeQuery = true)
-    Page<Curation> findByLikeCurations(Member member, Pageable pageable);
+            "AND m.member_id = :memberId AND c.curation_status = 'CURATION_ACTIVE' " +
+            "AND c.visibility = 'PUBLIC'", nativeQuery = true)
+    Page<Curation> findByLikeCurations(@Param("memberId") Long memberId, Pageable pageable);
 
     Page<Curation> findByCategoryAndCurationStatusAndVisibility(Category category, Curation.CurationStatus curationStatus, Curation.Visibility visibility, Pageable pageable);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -162,7 +162,7 @@ public class CurationService {
 
     //내가 좋아요한 큐레이션 목록 조회
     public Page<Curation> getMyLikeCuration(int page, int size, Member member) {
-        Page<Curation> myCurations = curationRepository.findByLikeCurations(member, PageRequest.of(page, size));
+        Page<Curation> myCurations = curationRepository.findByLikeCurations(member.getMemberId(), PageRequest.of(page, size));
 
         if(myCurations.getContent().size() == 0)
             throw new BusinessLogicException(ExceptionCode.CURATION_NOT_POST);


### PR DESCRIPTION
## 개요
- 좋아요한 큐레이션 목록조회 API가 멤버를 특정하여 기능하도록 수정
   --> 로그인한 회원 혹은 지정한 회원이 좋아요한 큐레이션 목록을 조회해야 하는데, 쿼리문 오류로 인해 정상작동하지 않음

## 작업사항
- 쿼리문이 지정한 memberId를 인자로 받도록 쿼리문 수정

### 참고사항
- 로컬테스트 완료

## 리뷰 요청사항
- 궁금하거나 개선해야할 부분이 있다면 코멘트 남겨주세요.