### PR TITLE
feat: 회원 프로필이미지 CRUD 기능

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
@@ -13,10 +13,12 @@ import com.seb_main_004.whosbook.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
@@ -49,10 +51,12 @@ public class MemberController {
         return new ResponseEntity(HttpStatus.CREATED);
     }
 
-    @PatchMapping
-    public ResponseEntity patchMember(@Valid @RequestBody MemberPatchDto memberPatchDto) {
+    @PatchMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity patchMember(@Valid @RequestPart MemberPatchDto memberPatchDto,
+                                      @RequestPart MultipartFile memberImage) {
+        boolean imageChange = memberPatchDto.isImageChange();
         Member member = memberMapper.memberPatchDtoToMember(memberPatchDto);
-        Member response = memberService.updateMember(member, getAuthenticatedEmail());
+        Member response = memberService.updateMember(member, imageChange, memberImage, getAuthenticatedEmail());
 
         return new ResponseEntity(memberMapper.memberToMemberResponseDto(response), HttpStatus.OK);
     }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/MemberPatchDto.java
@@ -2,6 +2,7 @@ package com.seb_main_004.whosbook.member.dto;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
@@ -10,10 +11,10 @@ import javax.validation.constraints.Size;
 public class MemberPatchDto {
     @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,15}$", message = "닉네임은 2글자 이상 15글자 미만의 영어, 한글, 숫자로 이루어져야 합니다.")
     private String nickname;
-
     @Size(min = 1, max = 200, message = "텍스트는 최대 200자까지 입력 가능합니다.")
     private String introduction;
-
-//    이미지 수정은 논의 후 구현예정
-//    private String image;
+    //프로필이미지 수정 여부를 알려주는 parameter
+    @NotNull
+    private boolean imageChange;
 }
+

--- a/server/src/main/java/com/seb_main_004/whosbook/member/entity/Member.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/entity/Member.java
@@ -33,8 +33,11 @@ public class Member {
 
     private String introduction;
 
-    //이미지 더미데이터
-    private String image = "이미지파일(더미)";
+    //이미지 조회용 url
+    private String imageUrl;
+
+    //S3 Bucket 이미지 key
+    private String imageKey;
 
     //소셜회원가입시 넘어오는 이미지
     private String imgUrl;

--- a/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapper.java
@@ -1,8 +1,5 @@
 package com.seb_main_004.whosbook.member.mapper;
 
-import com.seb_main_004.whosbook.curation.dto.CurationMultiResponseDto;
-import com.seb_main_004.whosbook.curation.dto.CurationSingleDetailResponseDto;
-import com.seb_main_004.whosbook.curation.entity.Curation;
 import com.seb_main_004.whosbook.member.dto.*;
 import com.seb_main_004.whosbook.member.entity.Member;
 import org.mapstruct.Mapper;
@@ -22,7 +19,7 @@ public interface MemberMapper {
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .introduction(member.getIntroduction())
-                .image(member.getImage())
+                .image(member.getImageUrl())
                 .mySubscriber(member.getSubscribingMembers().size())
                 .myCuration(member.getCurations().size())
                 .memberStatus(member.getMemberStatus())
@@ -35,7 +32,7 @@ public interface MemberMapper {
                 .email(otherMember.getEmail())
                 .nickname(otherMember.getNickname())
                 .introduction(otherMember.getIntroduction())
-                .image(otherMember.getImage())
+                .image(otherMember.getImageUrl())
                 .mySubscriber(otherMember.getSubscribingMembers().size())
                 .myCuration(otherMember.getCurations().size())
                 .isSubscribed(isSubscribed)

--- a/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.seb_main_004.whosbook.member.service;
 import com.seb_main_004.whosbook.auth.utils.CustomAuthorityUtils;
 import com.seb_main_004.whosbook.exception.BusinessLogicException;
 import com.seb_main_004.whosbook.exception.ExceptionCode;
+import com.seb_main_004.whosbook.image.service.StorageService;
 import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.repository.MemberRepository;
 import com.seb_main_004.whosbook.subscribe.entity.Subscribe;
@@ -12,11 +13,14 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+
 
 @Service
 public class MemberService {
@@ -24,14 +28,15 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final CustomAuthorityUtils authorityUtils;
     private final SubscribeRepository subscribeRepository;
+    private final StorageService storageService;
+    private final static String MEMBER_IMAGE_PATH = "memberImages";
 
-
-
-    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder, CustomAuthorityUtils authorityUtils, SubscribeRepository subscribeRepository) {
+    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder, CustomAuthorityUtils authorityUtils, SubscribeRepository subscribeRepository, StorageService storageService) {
         this.memberRepository = memberRepository;
         this.passwordEncoder = passwordEncoder;
         this.authorityUtils = authorityUtils;
         this.subscribeRepository = subscribeRepository;
+        this.storageService = storageService;
     }
 
     public Member createMember(Member member) {
@@ -54,15 +59,33 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-    public Member updateMember(Member member, String authenticatedEmail) {
+    public Member updateMember(Member member, boolean imageChange, MultipartFile image, String authenticatedEmail) {
         Member findMember = findVerifiedMemberByEmail(authenticatedEmail);
+        findMember.setUpdatedAt(LocalDateTime.now());
+
+        System.out.println("이미지사이즈: "+image.getSize());
+        //프로필 이미지 수정요청이 있을 경우
+        if(imageChange == true) {
+            //수정할 프로필 이미지가 없을 경우
+            long imageSize = image.getSize();
+            if(imageSize == 0) {
+                String imageKey = findMember.getImageKey();
+                findMember.setImageUrl(null);
+                findMember.setImageKey(null);
+                storageService.delete(imageKey);
+//                storageService.delete(findMember.getImageKey());
+            } else {
+                String imageKey = storageService.makeObjectKey(image, MEMBER_IMAGE_PATH, member.getMemberId());
+                String memberImage = storageService.store(image, imageKey);
+                findMember.setImageKey(imageKey);
+                findMember.setImageUrl(memberImage);
+            }
+        }
 
         Optional.ofNullable(member.getNickname())
                 .ifPresent(nickname->findMember.setNickname(nickname));
         Optional.ofNullable(member.getIntroduction())
                 .ifPresent(introduction->findMember.setIntroduction(introduction));
-
-        findMember.setUpdatedAt(LocalDateTime.now());
 
         return memberRepository.save(findMember);
     }
@@ -114,6 +137,12 @@ public class MemberService {
         if(member.getMemberStatus()==Member.MemberStatus.MEMBER_DELETE)
             throw new BusinessLogicException(ExceptionCode.MEMBER_HAS_BEEN_DELETED);
 
+        //회원 프로필 이미지가 있을 경우
+        if(member.getImageUrl() != null) {
+            storageService.delete(member.getImageKey());
+            member.setImageUrl(null);
+            member.setImageKey(null);
+        }
         member.setMemberStatus(Member.MemberStatus.MEMBER_DELETE);
 
         memberRepository.save(member);


### PR DESCRIPTION
## 개요
- 회원 프로필이미지 CRUD 기능 구현
  -> 로그인 후 memberPatch()를 이용하여 프로필 이미지를 추가, 수정 할 수 있음

## 작업사항
- 기존에 구현되어 있던, S3StorageService 활용
- 프로필이미지를 기본으로 바꾸거 싶거나, 회원 탈퇴를 하는 경우 S3에 저장된 프로필 이미지 삭제 하도록 구현

### 참고사항
- 로컬테스트 완료

## 리뷰 요청사항
-개션할 점이나 궁금한 점이 있다면 코멘트 부탁드립니다!!