### PR TITLE
feat: 이미지 확장자 대소문자 여부 상관없는 검증 기능

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/image/utils/ImageStorageUtils.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/image/utils/ImageStorageUtils.java
@@ -22,7 +22,7 @@ public class ImageStorageUtils {
     }
 
     public static String getFileExtension(MultipartFile file) {
-        String fileName = file.getOriginalFilename();
+        String fileName = file.getOriginalFilename().toLowerCase();
         return fileName.substring(fileName.lastIndexOf(".") + 1);
     }
 }


### PR DESCRIPTION
## 개요
- Jpg, JPEG 같이 대문자 확장자 검증이 안되던 문제 해결

## 작업사항
- 이미지 확장자 부분을 모두 소문자로 변경

### 참고사항


### 스크린샷


## 리뷰 요청사항

