### PR TITLE
feat: 큐레이션 작성시 책정보 저장 및 조회 기능 구현

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/book/BookService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/book/BookService.java
@@ -1,0 +1,20 @@
+package com.seb_main_004.whosbook.book;
+
+import com.seb_main_004.whosbook.book.entity.Book;
+import com.seb_main_004.whosbook.book.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+    private final BookRepository bookRepository;
+
+    public Book getSavedBook(Book book){
+        Optional<Book> optionalBook = bookRepository.findBookByIsbn(book.getIsbn());
+        if(optionalBook.isPresent()) return optionalBook.get();
+        return bookRepository.save(book);
+    }
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/book/entity/Book.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/book/entity/Book.java
@@ -1,0 +1,36 @@
+package com.seb_main_004.whosbook.book.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Book {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long bookId;
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false)
+    private String authors;
+    @Column(nullable = false)
+    private String publisher;
+    private String thumbnail;
+    private String url;
+    @Column(nullable = false, unique = true)
+    private String isbn;
+
+    public Book(String title, String authors, String publisher, String thumbnail, String url, String isbn) {
+        this.title = title;
+        this.authors = authors;
+        this.publisher = publisher;
+        this.thumbnail = thumbnail;
+        this.url = url;
+        this.isbn = isbn;
+    }
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/book/entity/BookCuration.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/book/entity/BookCuration.java
@@ -1,0 +1,27 @@
+package com.seb_main_004.whosbook.book.entity;
+
+import com.seb_main_004.whosbook.curation.entity.Curation;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class BookCuration {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long bookCurationId;
+    @ManyToOne
+    @JoinColumn(name = "book_id")
+    private Book book;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "curation_id")
+    private Curation curation;
+
+    public BookCuration(Book book, Curation curation) {
+        this.book = book;
+        this.curation = curation;
+    }
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/book/repository/BookCurationRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/book/repository/BookCurationRepository.java
@@ -1,0 +1,7 @@
+package com.seb_main_004.whosbook.book.repository;
+
+import com.seb_main_004.whosbook.book.entity.BookCuration;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookCurationRepository extends JpaRepository<BookCuration, Long> {
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/book/repository/BookRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/book/repository/BookRepository.java
@@ -1,0 +1,10 @@
+package com.seb_main_004.whosbook.book.repository;
+
+import com.seb_main_004.whosbook.book.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+    Optional<Book> findBookByIsbn(String isbn);
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPostDto.java
@@ -1,5 +1,6 @@
 package com.seb_main_004.whosbook.curation.dto;
 
+import com.seb_main_004.whosbook.book.entity.Book;
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,5 +30,7 @@ public class CurationPostDto implements CurationImageDto{
     private List<Long> imageIds;
     @Positive(message = "카테고리 ID는 1 이상 입니다.")
     private long categoryId;
+    @NotNull(message = "책정보를 기입해주세요")
+    private Book books;
 
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationSingleDetailResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationSingleDetailResponseDto.java
@@ -1,5 +1,7 @@
 package com.seb_main_004.whosbook.curation.dto;
 
+import com.seb_main_004.whosbook.book.entity.Book;
+import com.seb_main_004.whosbook.book.entity.BookCuration;
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import com.seb_main_004.whosbook.member.dto.CuratorResponseDto;
 import lombok.Builder;
@@ -25,4 +27,5 @@ public class CurationSingleDetailResponseDto {
     private Curation.Visibility visibility;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private List<Book> books;
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/entity/Curation.java
@@ -1,6 +1,7 @@
 package com.seb_main_004.whosbook.curation.entity;
 
 
+import com.seb_main_004.whosbook.book.entity.BookCuration;
 import com.seb_main_004.whosbook.curation.category.Category;
 import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
 import com.seb_main_004.whosbook.like.entity.CurationLike;
@@ -54,6 +55,8 @@ public class Curation {
     @OneToMany(mappedBy = "curation", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
     private List<CurationSaveImage> curationSaveImages = new ArrayList<>();
 
+    @OneToMany(mappedBy = "curation", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    private List<BookCuration> bookCurations;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -42,6 +42,9 @@ public interface CurationMapper {
                 .updatedAt(curation.getUpdatedAt())
                 .imageIds(curation.getCurationSaveImages().stream().map(
                         image -> image.getCurationImage().getCurationImageId()).collect(Collectors.toList()))
+                .books(curation.getBookCurations().stream().map(
+                        bookCuration -> bookCuration.getBook()
+                ).collect(Collectors.toList()))
                 .build();
     }
 

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -1,5 +1,9 @@
 package com.seb_main_004.whosbook.curation.service;
 
+import com.seb_main_004.whosbook.book.BookService;
+import com.seb_main_004.whosbook.book.entity.Book;
+import com.seb_main_004.whosbook.book.entity.BookCuration;
+import com.seb_main_004.whosbook.book.repository.BookCurationRepository;
 import com.seb_main_004.whosbook.curation.category.Category;
 import com.seb_main_004.whosbook.curation.category.CategoryService;
 import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
@@ -43,6 +47,8 @@ public class CurationService {
     private final CategoryService categoryService;
     private final CurationLikeRepository curationLikeRepository;
     private final SubscribeRepository subscribeRepository;
+    private final BookService bookService;
+    private final BookCurationRepository bookCurationRepository;
 
     @Transactional
     public Curation createCuration(Curation curation, CurationPostDto postDto, String authenticatedEmail){
@@ -54,6 +60,11 @@ public class CurationService {
 
         Curation savedCuration = curationRepository.save(curation);
 
+        // 저장된 큐레이션과 책 연결
+        Book savedBook = bookService.getSavedBook(postDto.getBooks());
+        bookCurationRepository.save(new BookCuration(savedBook, savedCuration));
+
+        // 이미지 저장 로직
         if (!postDto.getImageIds().isEmpty()){
             log.info("# 포스트 중 삭제된 이미지 없는지 검증실행 ");
             List<CurationImage> curationImages = curationImageService.verifyCurationSaveImages(postDto, member.getMemberId());


### PR DESCRIPTION
## 개요
- 큐레이션 작성시 외부 API와 연동한 책 데이터 저장 기능
- 단일 상세 큐레이션 조회시 큐레이션 작성 때 저장된 책 데이터 조회

## 작업사항
- Entity : 
  - `Book` - 책정보 테이블
  - `BookCuration - `Curation`과 `Book` 다대다 매핑을 위한 연결 테이블
- Repository : `Book`, `BookCration` 저장을 위한 Repository 클래스 작성
- Service : `BookService` - `getSavedBook()` 메소드 구현 :  이미 존재하는 책 데이터인지 확인 -> 존재하면 DB에 있는 Book 데이터 반환 -> 존재하지 않다면 DB에 저장 후 책데이터 반환
- 단일 상세 큐레이션 조회시 책 데이터 조회를 위한 Dto 매핑 작업

### 참고사항
- 큐레이션 안에서 책 정보 등록과 조회만 가능하고 책을 별도로 저장하거나 하는 로직은 아직 구현하지 않았습니다.
- 추후 큐레이션 수정시 책정보가 수정 될 때 해당 부분을 반영하는 것도 구현 할 예정입니다.
- 큐레이션 저장시 굉장히 많은 테이블에 저장이 일어나서.. 추후 더 개선 할 수 없는지 고민해봐야 할 것 같습니다
- 생각보다 단일 큐레이션 조회 속도가 빠릅니다? 20ms 미만으로 나오네요 ..

### 스크린샷
![image](https://github.com/codestates-seb/seb44_main_004/assets/122109213/dca5337e-1ef1-431e-ab89-3e761d6426a6)
![image](https://github.com/codestates-seb/seb44_main_004/assets/122109213/fe016b40-29de-4629-98dd-99e6f099b6af)
![image](https://github.com/codestates-seb/seb44_main_004/assets/122109213/b90333cd-411c-4e08-90cc-e157441470c7)


## 리뷰 요청사항
- 참고사항의 예외 처리 이외에 추가로 필요한 부분이 있을 지 조언 부탁드립니다.
