### PR TITLE
feat: 뉴, 베스트 큐레이션 카테고리별 조회 기능

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/controller/CurationController.java
@@ -76,8 +76,10 @@ public class CurationController {
 
     @GetMapping("/new")
     public ResponseEntity getNewCurationList(@RequestParam("page") int page,
-                                             @RequestParam("size") int size){
-        Page<Curation> curationPage = curationService.getNewCurations(page - 1, size);
+                                             @RequestParam("size") int size,
+                                             @RequestParam(value = "category", required = false) Long categoryId){
+        log.info("# NEW 큐레이션 리스트 조회 호출");
+        Page<Curation> curationPage = curationService.getNewCurations(page - 1, size, categoryId);
         List<Curation> curations = curationPage.getContent();
         return new ResponseEntity(new MultiResponseDto<>(
                 mapper.curationsToCurationListResponseDtos(curations), curationPage),
@@ -86,8 +88,10 @@ public class CurationController {
 
     @GetMapping("/best")
     public ResponseEntity getBestCurationList(@RequestParam("page") int page,
-                                              @RequestParam("size") int size){
-        Page<Curation> curationPage = curationService.getBestCurations(page - 1, size);
+                                              @RequestParam("size") int size,
+                                              @RequestParam(value = "category", required = false) Long categoryId){
+        log.info("# BEST 큐레이션 리스트 조회 호출");
+        Page<Curation> curationPage = curationService.getBestCurations(page - 1, size, categoryId);
         List<Curation> curations = curationPage.getContent();
         return new ResponseEntity(new MultiResponseDto<>(
                 mapper.curationsToCurationListResponseDtos(curations), curationPage),

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/repository/CurationRepository.java
@@ -2,7 +2,6 @@ package com.seb_main_004.whosbook.curation.repository;
 
 import com.seb_main_004.whosbook.curation.category.Category;
 import com.seb_main_004.whosbook.curation.entity.Curation;
-import com.seb_main_004.whosbook.like.entity.CurationLike;
 import com.seb_main_004.whosbook.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,13 +9,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface CurationRepository extends JpaRepository<Curation, Long> {
 
     Curation findByCurationId(long curationId);
 
-    Page<Curation> findByCurationStatusAndVisibility(Curation.CurationStatus curationStatus, Curation.Visibility visibility, Pageable pageable);
+    // 추후 고민 필요 : select 쿼리문이 3번 나감
+    @Query("select c from Curation c where (:category is null or c.category.id = :category) " +
+            "and c.visibility = 'PUBLIC' " +
+            "and c.curationStatus = 'CURATION_ACTIVE'")
+    Page<Curation> findCurationList(@Param("category") Long categoryId, Pageable pageable);
 
     Page<Curation> findByMemberAndCurationStatus(Member member, Curation.CurationStatus curationStatus, Pageable pageable);
 

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/service/CurationService.java
@@ -4,7 +4,6 @@ import com.seb_main_004.whosbook.book.BookService;
 import com.seb_main_004.whosbook.book.entity.Book;
 import com.seb_main_004.whosbook.book.entity.BookCuration;
 import com.seb_main_004.whosbook.book.repository.BookCurationRepository;
-import com.seb_main_004.whosbook.curation.category.Category;
 import com.seb_main_004.whosbook.curation.category.CategoryService;
 import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
 import com.seb_main_004.whosbook.curation.dto.CurationPostDto;
@@ -19,7 +18,6 @@ import com.seb_main_004.whosbook.like.entity.CurationLike;
 import com.seb_main_004.whosbook.like.repository.CurationLikeRepository;
 import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.service.MemberService;
-import com.seb_main_004.whosbook.reply.entity.Reply;
 import com.seb_main_004.whosbook.subscribe.entity.Subscribe;
 import com.seb_main_004.whosbook.subscribe.repository.SubscribeRepository;
 import lombok.RequiredArgsConstructor;
@@ -150,20 +148,18 @@ public class CurationService {
         return curation;
     }
     @Transactional(readOnly = true)
-    public Page<Curation> getNewCurations(int page, int size){
+    public Page<Curation> getNewCurations(int page, int size, Long categoryId){
         // 추후 리팩토링 필요
-        return curationRepository.findByCurationStatusAndVisibility(
-                Curation.CurationStatus.CURATION_ACTIVE,
-                Curation.Visibility.PUBLIC,
+        return curationRepository.findCurationList(
+                categoryId,
                 PageRequest.of(page, size, Sort.by("curationId").descending()));
     }
 
     @Transactional(readOnly = true)
-    public Page<Curation> getBestCurations(int page, int size){
+    public Page<Curation> getBestCurations(int page, int size, Long categoryId){
         // 추후 리팩토링 필요
-        return curationRepository.findByCurationStatusAndVisibility(
-                Curation.CurationStatus.CURATION_ACTIVE,
-                Curation.Visibility.PUBLIC,
+        return curationRepository.findCurationList(
+                categoryId,
                 PageRequest.of(page, size, Sort.by("curationLikeCount").descending()));
     }
 


### PR DESCRIPTION
## 개요
- NEW, BEST 큐레이션 리스트 조회시 카테고리별 필터 기능

## 작업사항
- CurationRepository 에서 queryParam 여부에 따라 category가 포함 또는 포함되지 않도록 구현
- new, best GET 매핑된 컨트롤러 메소드에 `category` param 추가

### 참고사항
- 일단 지금은 조회시 select 쿼리문이 3번 나가게 됩니다 추후에 한번에 가져 올 수는 없는지 더 공부해보고 리팩토링을 해야 할 수도 있을 것 같습니다.
- QueryDsl의 필요성을 점점 느낍니다.

### 스크린샷


## 리뷰 요청사항

