### PR TITLE
feat: 책정보 수정 기능 구현

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/advice/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/advice/GlobalExceptionAdvice.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.validation.ConstraintViolationException;
 
-//@RestControllerAdvice
+@RestControllerAdvice
 public class GlobalExceptionAdvice {
 
     @ExceptionHandler

--- a/server/src/main/java/com/seb_main_004/whosbook/book/BookService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/book/BookService.java
@@ -2,10 +2,14 @@ package com.seb_main_004.whosbook.book;
 
 import com.seb_main_004.whosbook.book.entity.Book;
 import com.seb_main_004.whosbook.book.repository.BookRepository;
+import com.seb_main_004.whosbook.curation.dto.CurationPatchDto;
+import com.seb_main_004.whosbook.curation.entity.Curation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/dto/CurationPatchDto.java
@@ -1,5 +1,6 @@
 package com.seb_main_004.whosbook.curation.dto;
 
+import com.seb_main_004.whosbook.book.entity.Book;
 import com.seb_main_004.whosbook.curation.entity.Curation;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,4 +29,6 @@ public class CurationPatchDto implements CurationImageDto{
     private List<Long> imageIds;
     @Positive(message = "카테고리 ID는 1 이상 입니다.")
     private long categoryId;
+    @NotNull(message = "책정보를 기입해주세요")
+    private Book books;
 }


### PR DESCRIPTION
## 개요
- 큐레이션 수정시 책정보 수정 기능

## 작업사항
- `CurationService` 에서 `updateCuration()` 메소드 수정
- 책정보가 바뀌었는지 검증하고 큐레이션과 책정보 연결 관계 업데이트 로직 구현

### 참고사항
- 공통 advice가 주석처리 되어있어서 다시 주석처리 해제하고 pr 날립니다!
- 일단 단일 책정보에 대한 것만 염두하고 기능을 빠르게 구현했습니다
- 추후 복수 책정보에 대한 부분으로 업데이트 되면 수정하도록 하겠습니다!

### 스크린샷

## 리뷰 요청사항

