### PR TITLE
feat: curator 응답값에 프로필이미지 url 추가

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/curation/mapper/CurationMapper.java
@@ -54,6 +54,7 @@ public interface CurationMapper {
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .introduction(member.getIntroduction())
+                .image(member.getImageUrl())
                 .build();
     }
 

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/CuratorResponseDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/CuratorResponseDto.java
@@ -15,6 +15,5 @@ public class CuratorResponseDto {
 
     private String introduction;
 
-//    회원가입 시 이미지 업로드를 위한 변수로서, 추후 구현
-//    private String image;
+    private String image;
 }


### PR DESCRIPTION
## 개요
- 단일 큐레이션 조회시 curator 응답값에 프로필이미지 url 추가

## 작업사항
- memberToCurator 매핑에 매핑 추가
- CuratorResponseDto에 image 필드 추가

### 참고사항


### 스크린샷


## 리뷰 요청사항

