### PR TITLE
[Client] Best / New 큐레이션 리스트 + Category API 요청 기능 구현

### DIFF
--- a/client/src/components/category/CategoryTag.tsx
+++ b/client/src/components/category/CategoryTag.tsx
@@ -1,51 +1,39 @@
 import tw from 'twin.macro';
 import styled from 'styled-components';
-
+import { axiosInstance } from '../../api/axios';
 import Button from '../../components/buttons/Button';
-
+import { useState, useEffect } from 'react';
 interface CategoryTagValue {
-  value: string;
-  key: number;
+  name: string;
+  categoryId: number;
 }
+interface CategoryTagsProps {
+  handleTagClick: (data: number) => void;
+}
+const CategoryTags = ({ handleTagClick }: CategoryTagsProps) => {
+  const [category, setCategory] = useState<CategoryTagValue[]>();
 
-const CategoryTags = () => {
-  const categoryData: CategoryTagValue[] = [
-    { value: "가정/육아", key: 1 },
-    { value: "건강", key: 2 },
-    { value: "경영/경제", key: 3 },
-    { value: "과학/공학", key: 4 },
-    { value: "만화", key: 5 },
-    { value: "문학", key: 6 },
-    { value: "사회과학", key: 7 },
-    { value: "소설", key: 8 },
-    { value: "수험서", key: 9 },
-    { value: "스포츠", key: 10 },
-    { value: "시/에세이", key: 11 },
-    { value: "역사/문화", key: 12 },
-    { value: "외국어", key: 13 },
-    { value: "여행", key: 14 },
-    { value: "요리", key: 15 },
-    { value: "유아", key: 16 },
-    { value: "인문", key: 17 },
-    { value: "자기계발", key: 18 },
-    { value: "잡지", key: 19 },
-    { value: "정치/사회", key: 20 },
-    { value: "종교", key: 21 },
-    { value: "재테크", key: 22 },
-    { value: "커리어", key: 23 },
-    { value: "IT", key: 24 },
-  ];
+  const getCategory = async () => {
+    const response = await axiosInstance.get('/category');
+    if (response) {
+      setCategory(response.data);
+    }
+  };
+
+  useEffect(() => {
+    getCategory();
+  }, []);
 
   return (
     <CategoryContainer>
-      {categoryData.map((category: CategoryTagValue) => (
-        <Category key={category.key}>
-          <Button type="category" content={category.value} />
+      {category?.map((category: CategoryTagValue) => (
+        <Category key={category.categoryId} onClick={() => handleTagClick(category.categoryId)}>
+          <Button type="category" content={category.name} />
         </Category>
       ))}
     </CategoryContainer>
   );
-}
+};
 
 const CategoryContainer = styled.div`
   ${tw`

--- a/client/src/components/curations/CurationDetailInfo.tsx
+++ b/client/src/components/curations/CurationDetailInfo.tsx
@@ -15,11 +15,12 @@ interface CurationDetailInfoProps {
   setIsLiked: (data: boolean) => void;
   curationLikeCount: number | undefined;
   curatorId: number | undefined;
-  curationId: string | undefined;
+  curationId: number | undefined;
+  category: string | undefined;
 }
 type likeDeleteProps = {
   memberId: number | undefined;
-  curationId: string | undefined;
+  curationId: number | undefined;
 };
 const CurationDetailInfo = ({
   isLiked,
@@ -27,6 +28,7 @@ const CurationDetailInfo = ({
   curationLikeCount,
   curatorId,
   curationId,
+  category,
 }: CurationDetailInfoProps) => {
   const token = localStorage.getItem('Authorization');
   const navigate = useNavigate();
@@ -57,7 +59,7 @@ const CurationDetailInfo = ({
     <DetailInfoContainer>
       <UserInfo>
         <Category>
-          <Button type="category" content="시/에세이" />
+          <Button type="category" content={category} />
         </Category>
         {memberId !== curatorId && (
           <>

--- a/client/src/components/input/SelectBox.tsx
+++ b/client/src/components/input/SelectBox.tsx
@@ -1,30 +1,44 @@
-import styled from "styled-components";
-import { useState, MouseEventHandler } from 'react';
+import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+import { axiosInstance } from '../../api/axios';
 
 interface OptionData {
-  value: string;
-  key: number;
+  name: string;
+  categoryId: number;
 }
+interface CategorySelectBoxProps {
+  setCategoryId: (categoryId: number) => void;
+}
+const CategorySelectBox = ({ setCategoryId }: CategorySelectBoxProps) => {
+  const [isShow, setIsShow] = useState<boolean>(false);
+  const [category, setCategory] = useState<OptionData[]>();
+  const [currentValue, setCurrentValue] = useState<string>('카테고리를 선택하세요');
 
-const CustomSelect = ({ optionData }: { optionData: OptionData[] }) => {
-  const [currentValue, setCurrentValue] = useState(optionData[0].value);
-  const [showOptions, setShowOptions] = useState(false);
-
-  const handleOnChangeSelectValue: MouseEventHandler<HTMLLIElement> = (e) => {
-    setCurrentValue(e.currentTarget.getAttribute("value") || "");
+  const getCategory = async () => {
+    const response = await axiosInstance.get('/category');
+    if (response) {
+      setCategory(response.data);
+    }
   };
 
+  useEffect(() => {
+    getCategory();
+  }, []);
+
   return (
-    <SelectBox onClick={() => setShowOptions((prev) => !prev)}>
+    <SelectBox onClick={() => setIsShow((prev) => !prev)}>
       <CategoryLabel>{currentValue}</CategoryLabel>
-      <SelectOptions show={showOptions}>
-        {optionData.map((data: OptionData) => (
+      <SelectOptions show={isShow}>
+        {category?.map((e, idx) => (
           <Option
-            key={data.key}
-            value={data.value}
-            onClick={handleOnChangeSelectValue}
+            key={idx}
+            value={e.name}
+            onClick={() => {
+              setCategoryId(e.categoryId);
+              setCurrentValue(e.name);
+            }}
           >
-            {data.value}
+            {e.name}
           </Option>
         ))}
       </SelectOptions>
@@ -32,51 +46,18 @@ const CustomSelect = ({ optionData }: { optionData: OptionData[] }) => {
   );
 };
 
-const CategorySelectBox = () => {
-  return (
-    <CustomSelect
-    optionData={[
-      { value: "카테고리를 선택해 주세요", key: 1 },
-      { value: "가정/육아", key: 2 },
-      { value: "건강", key: 3 },
-      { value: "경영/경제", key: 4 },
-      { value: "과학/공학", key: 5 },
-      { value: "만화", key: 6 },
-      { value: "문학", key: 7 },
-      { value: "사회과학", key: 8 },
-      { value: "소설", key: 9 },
-      { value: "수험서", key: 10 },
-      { value: "스포츠", key: 11 },
-      { value: "시/에세이", key: 12 },
-      { value: "역사/문화", key: 13 },
-      { value: "외국어", key: 14 },
-      { value: "여행", key: 15 },
-      { value: "요리", key: 16 },
-      { value: "유아", key: 17 },
-      { value: "인문", key: 18 },
-      { value: "자기계발", key: 19 },
-      { value: "잡지", key: 20 },
-      { value: "정치/사회", key: 21 },
-      { value: "종교", key: 22 },
-      { value: "재테크", key: 23 },
-      { value: "커리어", key: 24 },
-      { value: "IT", key: 25 },
-    ]}
-  />
-)}
-
 export default CategorySelectBox;
 
 const SelectBox = styled.div`
   position: relative;
   width: 100%;
-  padding: .6rem;
-  border-radius: .3rem;
+  padding: 0.6rem;
+  border-radius: 0.3rem;
   background-color: #f8f7f7;
   align-self: center;
   cursor: pointer;
   &::before {
-  content: "⌵";
+    content: '⌵';
     position: absolute;
     top: 4px;
     right: 12px;
@@ -86,7 +67,7 @@ const SelectBox = styled.div`
 `;
 
 const CategoryLabel = styled.label`
-  font-size: .8rem;
+  font-size: 0.8rem;
   margin: 5px;
   text-align: center;
   color: #757575;
@@ -100,15 +81,15 @@ const SelectOptions = styled.ul<{ show: boolean }>`
   width: 100%;
   overflow: hidden;
   overflow: auto;
-  height: ${(props) => (props.show ? "110px" : "0")};
+  height: ${(props) => (props.show ? '110px' : '0')};
   padding: 0;
-  border-radius: .3rem;
+  border-radius: 0.3rem;
   background-color: #f8f7f7;
   color: #757575;
 `;
 
 const Option = styled.li`
-  font-size: .8rem;
+  font-size: 0.8rem;
   padding: 12px;
   transition: background-color 0.05s ease-in;
   &:hover {

--- a/client/src/pages/Curation/BestCurationPage.tsx
+++ b/client/src/pages/Curation/BestCurationPage.tsx
@@ -44,6 +44,7 @@ const BestCurationPage = () => {
     const response = await LikedCurationCategoryAPI(page + 1, itemsPerPage, categoryId);
     if (!response?.data.data.length) {
       setIsLoading(false);
+      setBestCurations(response?.data.data);
     } else {
       setBestCurations(response.data.data);
       setTotalBestPage(response.data.pageInfo.totalPages);

--- a/client/src/pages/Curation/BestCurationPage.tsx
+++ b/client/src/pages/Curation/BestCurationPage.tsx
@@ -5,7 +5,7 @@ import { styled } from 'styled-components';
 import tw from 'twin.macro';
 
 import CategoryTag from '../../components/category/CategoryTag';
-import { LikedCurationAPI } from '../../api/curationApi';
+import { LikedCurationAPI, LikedCurationCategoryAPI } from '../../api/curationApi';
 import { ICurationResponseData } from '../../types/main';
 import CurationCard from '../../components/cards/CurationCard';
 import Label from '../../components/label/Label';
@@ -40,7 +40,20 @@ const BestCurationPage = () => {
       setIsLoading(false);
     }
   };
-
+  const getBestCurationsByCategory = async (page: number, categoryId: number) => {
+    const response = await LikedCurationCategoryAPI(page + 1, itemsPerPage, categoryId);
+    if (!response?.data.data.length) {
+      setIsLoading(false);
+    } else {
+      setBestCurations(response.data.data);
+      setTotalBestPage(response.data.pageInfo.totalPages);
+      setIsLoading(false);
+    }
+  };
+  const handleTagClick = (categoryId: number) => {
+    setPage(0);
+    getBestCurationsByCategory(page, categoryId);
+  };
   const handlePageChange = (selectedPage: { selected: number }) => {
     setPage(selectedPage.selected);
   };
@@ -60,7 +73,7 @@ const BestCurationPage = () => {
             </Link>
           </CreateButton>
         </TitleContainer>
-        <CategoryTag />
+        <CategoryTag handleTagClick={handleTagClick} />
         <Section>
           <Label type="title" content="Best 큐레이션" />
           <br />

--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -36,7 +36,8 @@ export interface Curation {
   updatedAt: string;
   curator: Curator;
   deleted: boolean;
-  //books: SelectedBook
+  books: SelectedBook;
+  category: string;
 }
 
 export interface Curator {
@@ -273,7 +274,8 @@ const CurationDetailPage = () => {
                   setIsLiked={setIsLiked}
                   curationLikeCount={curation?.curationLikeCount}
                   curatorId={curator?.memberId}
-                  curationId={curationId}
+                  curationId={Number(curationId)}
+                  category={curation.category}
                 />
               </DetailInfoLeft>
               <DetailInfoRight>

--- a/client/src/pages/Curation/CurationWritePage.tsx
+++ b/client/src/pages/Curation/CurationWritePage.tsx
@@ -41,7 +41,7 @@ const CurationWritePage = () => {
   const [emojiValue, setEmojiValue] = useState('');
   const [contentValue, setContentValue] = useState('');
   const [imageIds] = useState<string[]>([]);
-  const [categoryId] = useState<number>(1);
+
   const [visibilityValue, setVisibilityValue] = useState('PUBLIC');
   const [isModal, setIsModal] = useState<boolean>(false);
   const [title, setTitle] = useState<string>('');
@@ -49,6 +49,8 @@ const CurationWritePage = () => {
   const [book, setBook] = useState<SelectedBook | null>(null);
   const quillRef = useRef(null);
   const navigate = useNavigate();
+
+  const [categoryId, setCategoryId] = useState<number>(0);
 
   const handleValidation = () => {
     if (!emojiValue) {
@@ -194,7 +196,7 @@ const CurationWritePage = () => {
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="title" content="카테고리" />
-            <SelectBox />
+            <SelectBox setCategoryId={setCategoryId} />
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="title" content="추천하는 책" />

--- a/client/src/pages/Curation/NewCurationPage.tsx
+++ b/client/src/pages/Curation/NewCurationPage.tsx
@@ -5,7 +5,7 @@ import { styled } from 'styled-components';
 import tw from 'twin.macro';
 
 import CategoryTag from '../../components/category/CategoryTag';
-import { newlyCurationAPI } from '../../api/curationApi';
+import { newlyCurationAPI, newlyCurationCategoryAPI } from '../../api/curationApi';
 import { ICurationResponseData } from '../../types/main';
 import CurationCard from '../../components/cards/CurationCard';
 import Label from '../../components/label/Label';
@@ -41,6 +41,22 @@ const NewCurationPage = () => {
     }
   };
 
+  const getNewlyCurationsByCategory = async (page: number, categoryId: number) => {
+    const response = await newlyCurationCategoryAPI(page + 1, itemsPerPage, categoryId);
+
+    if (!response?.data.data.length) {
+      setIsLoading(false);
+    } else {
+      setNewCurations(response.data.data);
+      setTotalNewPage(response.data.pageInfo.totalPages);
+      setIsLoading(false);
+    }
+  };
+
+  const handleTagClick = (categoryId: number) => {
+    setPage(0);
+    getNewlyCurationsByCategory(page, categoryId);
+  };
   const handlePageChange = (selectedPage: { selected: number }) => {
     setPage(selectedPage.selected);
   };
@@ -60,7 +76,7 @@ const NewCurationPage = () => {
             </Link>
           </CreateButton>
         </TitleContainer>
-        <CategoryTag />
+        <CategoryTag handleTagClick={handleTagClick} />
         <Section>
           <Label type="title" content="New 큐레이션" />
           <br />

--- a/client/src/pages/Curation/NewCurationPage.tsx
+++ b/client/src/pages/Curation/NewCurationPage.tsx
@@ -46,6 +46,7 @@ const NewCurationPage = () => {
 
     if (!response?.data.data.length) {
       setIsLoading(false);
+      setNewCurations(response?.data.data);
     } else {
       setNewCurations(response.data.data);
       setTotalNewPage(response.data.pageInfo.totalPages);

--- a/client/src/store/categorySlice.ts
+++ b/client/src/store/categorySlice.ts
@@ -1,7 +1,10 @@
 import { createSlice } from '@reduxjs/toolkit';
-
+interface CategoryTagValue {
+  name: string;
+  categoryId: number;
+}
 export interface CategoryState {
-  categories: string[];
+  categories: CategoryTagValue[];
 }
 
 const initialState: CategoryState = {


### PR DESCRIPTION
## 개요

- BEST 큐레이션 리스트에서 카테고리 클릭 시 해당 카테고리에 맞는 큐레이션 리스트가 나오도록 구현
- NEW 큐레이션 리스트에서 카테고리 클릭 시 해당 카테고리에 맞는 큐레이션 리스트가 나오도록 구현

## 작업사항

- 기존 카테고리 목록을 불러오던 `CategoryTag.tsx`와 `SelecBox.tsx`에서 GET 요청을 통해 모든 카테고리를 불러왔습니다.
- `CurationWritePage.tsx`와 `CurationEditPage.tsx`에 categoryId라는 value값을 추가해, 사용자가 선택한 카테고리가 `CurationDetailPage`에도 나타나도록 구현했습니다.
- API를 사용하여 BEST/NEW큐레이션 페이지에서 특정 카테고리를 선택하면 > 해당 카테고리의 큐레이션이 나오면서 페이지네이션이 가능하도록 구현했습니다.

## 참고사항

- 카테고리 조회 요청 시, BEST/NEW큐레이션 페이지에서 특정 카테고리 버튼을 누를 때마다 요청이 전송되기에 조금 비효율적이라는 생각이 들어, @jiye-7 님이 Redux에 저장해주신 데이터를 사용하고자 합니다. 이는 리팩토링 예정입니다.
- 원래 @ella-yschoi 담당하는 파트였으나, @jeongjwon 님이 도와주셔서 함께 작업했습니다.

## 스크린샷

- BEST 큐레이션 페이지

  ![best 큐레이션](https://github.com/codestates-seb/seb44_main_004/assets/76391160/68293e78-0871-4fb4-a305-d1a4408609b4)

- NEW 큐레이션 페이지

  ![new 큐레이션](https://github.com/codestates-seb/seb44_main_004/assets/76391160/995b1548-0f32-4841-a59d-84299d06d496)


![image](https://github.com/codestates-seb/seb44_main_004/assets/76391160/7accd264-8b82-44b6-99c2-30d79e02f91b)

두 페이지의 첫 렌더링 시 비교를 하면 미교하게 데이터의 순서가 다른 것을 볼 수 있는데,
이는 BEST 큐레이션 페이지에서는 조회 요청을 하면 좋아요 순으로 데이터를 받아오기 때문입니다.

## 리뷰 요청사항

- 피드백은 언제나 환영입니다!
