### PR TITLE
refactor: bestCurator 조회시 N+1 문제 해결을 위한 쿼리 개선

### DIFF
--- a/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/controller/MemberController.java
@@ -6,11 +6,8 @@ import com.seb_main_004.whosbook.curation.mapper.CurationMapper;
 import com.seb_main_004.whosbook.curation.service.CurationService;
 import com.seb_main_004.whosbook.exception.BusinessLogicException;
 import com.seb_main_004.whosbook.exception.ExceptionCode;
-import com.seb_main_004.whosbook.member.dto.MemberPatchDto;
-import com.seb_main_004.whosbook.member.dto.MemberPostDto;
+import com.seb_main_004.whosbook.member.dto.*;
 import com.seb_main_004.whosbook.dto.MultiResponseDto;
-import com.seb_main_004.whosbook.member.dto.MemberResponseDto;
-import com.seb_main_004.whosbook.member.dto.SocialMemberPostDto;
 import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.mapper.MemberMapperClass;
 import com.seb_main_004.whosbook.member.service.MemberService;
@@ -184,10 +181,10 @@ public class MemberController {
     @GetMapping("/best")
     public ResponseEntity getBestCurators(@Positive @RequestParam("page") int page,
                                           @Positive @RequestParam("size") int size) {
-        Page<Member> memberPage = memberService.findBestCurators(page - 1, size);
-        List<Member> members = memberPage.getContent();
+        Page<BestCuratorDto> memberPage = memberService.findBestCurators(page - 1, size);
+        List<BestCuratorDto> members = memberPage.getContent();
 
-        return new ResponseEntity(new MultiResponseDto<>(memberMapperClass.membersToBestCuratorDtos(members), memberPage
+        return new ResponseEntity(new MultiResponseDto<>(members, memberPage
         ), HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/seb_main_004/whosbook/member/dto/BestCuratorDto.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/dto/BestCuratorDto.java
@@ -1,9 +1,10 @@
 package com.seb_main_004.whosbook.member.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
-@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
 @Getter
 public class BestCuratorDto {
     private long memberId;
@@ -16,5 +17,5 @@ public class BestCuratorDto {
 
     private String image;
 
-    private long mySubscriber;
+    private int mySubscriber;
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapperClass.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/mapper/MemberMapperClass.java
@@ -104,14 +104,14 @@ public class MemberMapperClass {
     }
 
     public BestCuratorDto memberToBestCuratorDto(Member member) {
-        return BestCuratorDto.builder()
-                .memberId(member.getMemberId())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .introduction(member.getIntroduction())
-                .image(member.getImageUrl())
-                .mySubscriber(member.getSubscribers().size())
-                .build();
+        return new BestCuratorDto(
+                member.getMemberId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getIntroduction(),
+                member.getImageUrl(),
+                member.getSubscribers().size()
+        );
     }
 
     public List<BestCuratorDto> membersToBestCuratorDtos(List<Member> members) {

--- a/server/src/main/java/com/seb_main_004/whosbook/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.seb_main_004.whosbook.member.repository;
 
+import com.seb_main_004.whosbook.member.dto.BestCuratorDto;
 import com.seb_main_004.whosbook.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,4 +21,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     "GROUP BY m.member_id " +
     "ORDER BY num_subscribers DESC", countQuery = "SELECT COUNT(*) FROM member", nativeQuery = true)
     Page<Member> findBestCurators(Pageable pageable);
+
+    @Query(value = "SELECT new com.seb_main_004.whosbook.member.dto.BestCuratorDto(m.memberId, m.email, m.nickname, m.introduction, m.imageUrl, SIZE(m.subscribers)) " +
+    "FROM Member m LEFT JOIN m.subscribers " +
+    "WHERE m.memberStatus = 'MEMBER_ACTIVE' " +
+    "GROUP BY m " +
+    "ORDER BY SIZE(m.subscribers) DESC")
+    Page<BestCuratorDto> findBestCuratorsTestV2(Pageable pageable);
 }

--- a/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.seb_main_004.whosbook.auth.utils.CustomAuthorityUtils;
 import com.seb_main_004.whosbook.exception.BusinessLogicException;
 import com.seb_main_004.whosbook.exception.ExceptionCode;
 import com.seb_main_004.whosbook.image.service.StorageService;
+import com.seb_main_004.whosbook.member.dto.BestCuratorDto;
 import com.seb_main_004.whosbook.member.entity.Member;
 import com.seb_main_004.whosbook.member.repository.MemberRepository;
 import com.seb_main_004.whosbook.subscribe.entity.Subscribe;
@@ -197,8 +198,8 @@ public class MemberService {
         return new PageImpl<>(pageContent, PageRequest.of(page, size), subscribingMembers.size());
     }
 
-    public Page<Member> findBestCurators(int page, int size) {
-        return memberRepository.findBestCurators(PageRequest.of(page, size));
+    public Page<BestCuratorDto> findBestCurators(int page, int size) {
+        return memberRepository.findBestCuratorsTestV2(PageRequest.of(page, size));
     }
 
     public boolean findIsSubscribed(String authenticatedEmail, Member otherMember) {


### PR DESCRIPTION
## 개요
- bestCurator 조회시 N+1 문제 해결을 위한 쿼리 개선

## 작업사항
-  각 큐레이터의 구독자 수를 `영속화된 컬렉션.size()` 로 불러서 맵핑하는 부분을 제거
- 데이터 쿼리로 조회된 데이터를 바로 BestCuratorDto에 주입해서 해당 BestCuratorDto를 반환

### 참고사항
- 다른 리스트 조회도 조금씩 손봐야 할 것 같습니다.

### 스크린샷

## 리뷰 요청사항