### PR TITLE
마이페이지, 타유저 페이지에서 목록 오류 수정

### DIFF
--- a/client/src/pages/User/MyPage.tsx
+++ b/client/src/pages/User/MyPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 
 import tw from 'twin.macro';
 import styled from 'styled-components';
@@ -10,7 +10,7 @@ import { UserPageType } from '../../types';
 import { saveUserInfo } from '../../store/userSlice';
 import { getMyInfoAPI } from '../../api/profileApi';
 
-import MyFilter from '../../components/filter/Filter';
+import Filter from '../../components/filter/Filter';
 import ProfileInfo from '../../components/profiles/ProfileInfo';
 import ProfileForm from '../../components/profiles/ProfileForm';
 import WrittenList from '../../components/profiles/WrittenList';
@@ -21,7 +21,7 @@ const MyPage = () => {
   const [selected, setSelected] = useState<number>(0);
 
   const dispatch = useDispatch();
-
+  const location = useLocation();
   const handleGetMyInfo = async () => {
     const response = await getMyInfoAPI();
     if (response) {
@@ -29,17 +29,28 @@ const MyPage = () => {
     }
   };
 
-  const handleSelected = () => {
-    const storedSelected = localStorage.getItem('selected');
-    if (storedSelected) {
-      setSelected(parseInt(storedSelected, 10));
-    }
-  };
-
   useEffect(() => {
     handleGetMyInfo();
-    handleSelected();
   }, []);
+
+  useEffect(() => {
+    switch (location.pathname) {
+      case '/mypage':
+        setSelected(0);
+        break;
+      case `/mypage/${RoutePath.MyWrittenPage}`:
+        setSelected(1);
+        break;
+      case `/mypage/${RoutePath.MyLikePage}`:
+        setSelected(2);
+        break;
+      case `/mypage/${RoutePath.MySubcriberPage}`:
+        setSelected(3);
+        break;
+      default:
+        break;
+    }
+  }, [location.pathname]);
 
   return (
     <MyPageContainer>
@@ -47,7 +58,7 @@ const MyPage = () => {
       <ProfileDetailContainer>
         <ProfileAside>
           <ul>
-            <MyFilter type={UserPageType.MYPAGE} selected={selected} setSelected={setSelected} />
+            <Filter type={UserPageType.MYPAGE} selected={selected} setSelected={setSelected} />
           </ul>
         </ProfileAside>
         <ProfileDetailMain>

--- a/client/src/pages/User/UserPage.tsx
+++ b/client/src/pages/User/UserPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 
 import tw from 'twin.macro';
 
@@ -14,20 +14,21 @@ import LikeList from '../../components/profiles/LikeList';
 import { ProfileDetailContainer, ProfileAside, ProfileDetailMain, MainContainer } from './MyPage';
 const UserPage = () => {
   const [selected, setSelected] = useState<number>(0);
+  const location = useLocation();
 
   useEffect(() => {
-    handleSelected();
-  }, []);
-
-  const handleSelected = () => {
-    const pathname = location.pathname;
-
-    if (pathname === RoutePath.UserWrittenPage) {
-      setSelected(0);
-    } else if (pathname === RoutePath.UserLikePage) {
-      setSelected(1);
+    switch (location.pathname) {
+      case `/userpage/${RoutePath.UserWrittenPage}`:
+        setSelected(0);
+        break;
+      case `/mypuserpageage/${RoutePath.UserLikePage}`:
+        setSelected(1);
+        break;
+      default:
+        break;
     }
-  };
+  }, [location.pathname]);
+
   return (
     <UserPageContainer>
       <ProfileInfo type={UserPageType.USERPAGE} />


### PR DESCRIPTION
## 개요
마이페이지, 타유저페이지에서 생긴 이슈를 수정하였습니다.

## 작업사항
- 마이페이지에서 구독하는 큐레이터 목록을 보고 있다가 마이페이지 외 다른 페이지를 접속 후, 마이페이지 접속 시 구독하는 큐레이터 목록 에 active 가 된 상태였습니다.
- 이를 필터 값을 초기화 시키는 과정을 진행하였습니다.

## 참고사항

## 스크린샷
- 수정 전
![수정 전](https://github.com/codestates-seb/seb44_main_004/assets/76391160/f9c926ca-abf5-4d61-83e7-ff8bbc07d0ad)

- 수정 후
![수정 후](https://github.com/codestates-seb/seb44_main_004/assets/76391160/c4acd0dc-cec7-492a-9e8f-2b213ebfa115)

## 리뷰 요청사항
- 참고사항의 예외 처리 이외에 추가로 예외 처리가 필요한 부분이 있을 지 조언 부탁드립니다.