### PR TITLE
단일 큐레이션 상세페이지 및 편집 페이지 수정

### DIFF
--- a/client/src/components/curations/CurationDetailInfo.tsx
+++ b/client/src/components/curations/CurationDetailInfo.tsx
@@ -33,6 +33,7 @@ const CurationDetailInfo = ({
   const token = localStorage.getItem('Authorization');
   const navigate = useNavigate();
   const { memberId } = useSelector((state: RootState) => state.user);
+
   const handleLike = async () => {
     if (token) {
       const response = await axiosInstance.post(`/curations/${curationId}/like`);
@@ -61,7 +62,7 @@ const CurationDetailInfo = ({
         <Category>
           <Button type="category" content={category} />
         </Category>
-        {memberId !== curatorId && (
+        {memberId !== curatorId ? (
           <>
             {isLiked ? (
               <LikeButton onClick={handleCancelLike}>
@@ -73,6 +74,10 @@ const CurationDetailInfo = ({
               </LikeButton>
             )}
           </>
+        ) : (
+          <LikeButton id="myLike">
+            <AiFillHeart size="2rem" />
+          </LikeButton>
         )}
         좋아요 {curationLikeCount}개
       </UserInfo>

--- a/client/src/components/input/SelectBox.tsx
+++ b/client/src/components/input/SelectBox.tsx
@@ -8,11 +8,17 @@ interface OptionData {
 }
 interface CategorySelectBoxProps {
   setCategoryId: (categoryId: number) => void;
+  currentValue: string;
+  setCurrentValue: (currentValue: string) => void;
 }
-const CategorySelectBox = ({ setCategoryId }: CategorySelectBoxProps) => {
+const CategorySelectBox = ({
+  setCategoryId,
+  currentValue,
+  setCurrentValue,
+}: CategorySelectBoxProps) => {
   const [isShow, setIsShow] = useState<boolean>(false);
   const [category, setCategory] = useState<OptionData[]>();
-  const [currentValue, setCurrentValue] = useState<string>('카테고리를 선택하세요');
+  // const [currentValue, setCurrentValue] = useState<string>('카테고리를 선택하세요');
 
   const getCategory = async () => {
     const response = await axiosInstance.get('/category');

--- a/client/src/components/modals/Modal.tsx
+++ b/client/src/components/modals/Modal.tsx
@@ -93,6 +93,8 @@ const Modal = ({
 export default Modal;
 
 const ModalBackdrop = tw.div`
+ w-full
+ h-full
     absolute
     z-30
     fixed

--- a/client/src/components/modals/Modal.tsx
+++ b/client/src/components/modals/Modal.tsx
@@ -8,28 +8,35 @@ interface ModalProps {
   type?: ModalType;
   handleCloseModal: () => void;
   handleCancelSubscribe?: () => void;
+  handleCompleteCommentDelete?: () => void;
   nickname?: string;
 }
-const Modal = ({ type, handleCloseModal, handleCancelSubscribe, nickname }: ModalProps) => {
+const Modal = ({
+  type,
+  handleCloseModal,
+  handleCancelSubscribe,
+  handleCompleteCommentDelete,
+  nickname,
+}: ModalProps) => {
   const title: Array<string> = [
     '후즈북의 큐레이터가 되신것을 환영합니다!',
     `${nickname}님의 큐레이션 구독을 취소하시겠어요?`,
+    `댓글을 정말 삭제하시겠습니까?`,
   ];
-
-  return (
-    <ModalBackdrop>
-      <ModalView>
-        <CloseBtn onClick={handleCloseModal}>
-          <MdOutlineClose size="1.2rem" />
-        </CloseBtn>
-        {type === ModalType.WELCOME ? (
+  const renderingModal = () => {
+    switch (type) {
+      case ModalType.WELCOME:
+        return (
           <>
             <ModalTitle>{title[0]}</ModalTitle>
             <ButtonZone>
               <Button type="primary" content="반가워요" onClick={handleCloseModal} />
             </ButtonZone>
           </>
-        ) : (
+        );
+        break;
+      case ModalType.SUBSCRIBE:
+        return (
           <>
             <ModalTitle>{title[1]}</ModalTitle>
             <ButtonZone>
@@ -47,7 +54,37 @@ const Modal = ({ type, handleCloseModal, handleCancelSubscribe, nickname }: Moda
               />
             </ButtonZone>
           </>
-        )}
+        );
+        break;
+      case ModalType.REPLY:
+        return (
+          <>
+            <ModalTitle>{title[2]}</ModalTitle>
+            <ButtonZone>
+              <Button
+                type="cancel"
+                content="삭제"
+                onClick={handleCompleteCommentDelete}
+                width="calc(30%-0.5rem)"
+              />
+              <Button
+                type="basic"
+                content="닫기"
+                onClick={handleCloseModal}
+                width="calc(40%-0.5rem)"
+              />
+            </ButtonZone>
+          </>
+        );
+    }
+  };
+  return (
+    <ModalBackdrop>
+      <ModalView>
+        <CloseBtn onClick={handleCloseModal}>
+          <MdOutlineClose size="1.2rem" />
+        </CloseBtn>
+        {renderingModal()}
       </ModalView>
     </ModalBackdrop>
   );

--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -379,7 +379,7 @@ const CurationDetailPage = () => {
 
             <ButtonContainer>
               <DetailButton>
-                {totalElement && replies.length < totalElement && (
+                {replies.length < totalElement && (
                   <Button type="detail" content="더보기" onClick={hanldeMoreComment} />
                 )}
               </DetailButton>

--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -87,7 +87,6 @@ const CurationDetailPage = () => {
 
   const replies = useSelector((state: RootState) => state.replies?.replies);
   const { memberId } = useSelector((state: RootState) => state.user);
-  const { memberId } = useSelector((state: RootState) => state.user);
   const { curationId } = useParams();
 
   const dispatch = useDispatch();
@@ -100,6 +99,7 @@ const CurationDetailPage = () => {
       navigate(`/edit/${curationId}`);
     } else {
       alert('이 큐레이션은 이미 삭제되었어요 🫥');
+      navigate('/login', { state: { from: location.pathname } });
     }
   };
 
@@ -107,10 +107,12 @@ const CurationDetailPage = () => {
     try {
       await axiosInstance.delete(`/curations/${curationId}`);
       alert('큐레이션이 정상적으로 삭제되었어요!');
+      navigate('/', { state: { from: location.pathname } });
       navigate(-1);
     } catch (error) {
       console.error(error);
       alert('큐레이션을 찾을 수 없어요 😔');
+      navigate('/', { state: { from: location.pathname } });
     }
   };
 
@@ -129,11 +131,11 @@ const CurationDetailPage = () => {
         console.error(error);
         if ((error as AxiosError)?.response?.status === 404) {
           alert('이 큐레이션은 이미 삭제되었어요 🫥');
-          navigate('/');
+          navigate('/', { state: { from: location.pathname } });
           // TODO: 404 에러 페이지로 연결 예정
         } else if ((error as AxiosError)?.response?.status === 403) {
           alert('비밀 글로 작성된 큐레이션 이에요 🔒');
-          navigate('/');
+          navigate('/', { state: { from: location.pathname } });
         }
       }
     };
@@ -152,12 +154,9 @@ const CurationDetailPage = () => {
     if (!response?.data.data.length) {
       const newReplies = response?.data.data;
       dispatch(saveReplies(newReplies));
-      const newReplies = response?.data.data;
-      dispatch(saveReplies(newReplies));
       setIsLoading(false);
     } else if (response.data.data.length) {
       const newReplies = response.data.data;
-      console.log(response);
       dispatch(saveReplies(newReplies));
       setTotalElement(response.data.pageInfo.totalElement);
     }
@@ -234,7 +233,7 @@ const CurationDetailPage = () => {
   useEffect(() => {
     if (curation && curation.deleted) {
       alert('이 큐레이션은 이미 삭제되었어요 🫥');
-      navigate('/');
+      navigate('/', { state: { from: location.pathname } });
     }
   }, [curation, navigate]);
 
@@ -249,8 +248,6 @@ const CurationDetailPage = () => {
   }, []);
   const isAuthor = () => {
     if (curation && curator) {
-      //큐레이션 작성자의 memberId 와 로그인 된 유저의 memberId 비교
-      return memberId === curator.memberId;
       //큐레이션 작성자의 memberId 와 로그인 된 유저의 memberId 비교
       return memberId === curator.memberId;
     }

--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -86,6 +86,7 @@ const CurationDetailPage = () => {
   const [limit, setLimit] = useState<number>(1);
 
   const replies = useSelector((state: RootState) => state.replies?.replies);
+  const { memberId } = useSelector((state: RootState) => state.user);
   const { curationId } = useParams();
 
   const dispatch = useDispatch();
@@ -237,7 +238,8 @@ const CurationDetailPage = () => {
 
   const isAuthor = () => {
     if (curation && curator) {
-      return curation.curator.memberId === curator.memberId;
+      //큐레이션 작성자의 memberId 와 로그인 된 유저의 memberId 비교
+      return memberId === curator.memberId;
     }
     return false;
   };
@@ -412,7 +414,7 @@ const FormContainer = styled.div`
 const TitleContainer = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  /* justify-content: space-between; */
   flex-direction: row;
   margin: 4rem 0rem 2rem 0rem;
   text-align: left;

--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -149,9 +149,12 @@ const CurationDetailPage = () => {
     };
     const response = await getRepliesAPI(Number(curationId), params);
     if (!response?.data.data.length) {
+      const newReplies = response?.data.data;
+      dispatch(saveReplies(newReplies));
       setIsLoading(false);
     } else if (response.data.data.length) {
       const newReplies = response.data.data;
+      console.log(response);
       dispatch(saveReplies(newReplies));
       setTotalElement(response.data.pageInfo.totalElement);
     }
@@ -235,7 +238,9 @@ const CurationDetailPage = () => {
   useEffect(() => {
     getReplies();
   }, [limit]);
-
+  useEffect(() => {
+    getReplies();
+  }, []);
   const isAuthor = () => {
     if (curation && curator) {
       //큐레이션 작성자의 memberId 와 로그인 된 유저의 memberId 비교

--- a/client/src/pages/Curation/CurationEditPage.tsx
+++ b/client/src/pages/Curation/CurationEditPage.tsx
@@ -49,7 +49,6 @@ export interface Curation {
   createdAt: string;
   updatedAt: string;
   curator: Curator;
-  categoryId: number;
   imageIds: number[];
   books: SelectedBook;
 }
@@ -75,6 +74,8 @@ const CurationEditPage = () => {
   const [book, setBook] = useState<SelectedBook | null>(null);
   // const [book, setBooks] = useState<SelectedBook | null>(null);
   const quillRef = useRef<ReactQuill | null>(null);
+  const [currentValue, setCurrentValue] = useState<string>('카테고리를 선택하세요');
+
   const { curationId } = useParams();
   const navigate = useNavigate();
 
@@ -114,8 +115,9 @@ const CurationEditPage = () => {
         setContentValue(curation?.content);
         setImageIds(curationData.imageIds);
         setVisibilityValue(curation?.visibility);
-        setBook(response.data.books);
+        setBook(response.data.books[0]);
         setCategoryId(response.data.categoryId);
+        setCurrentValue(response.data.category);
       } catch (error) {
         console.error(error);
       }
@@ -245,7 +247,11 @@ const CurationEditPage = () => {
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="title" content="카테고리" />
-            <SelectBox setCategoryId={setCategoryId}/>
+            <SelectBox
+              setCategoryId={setCategoryId}
+              currentValue={currentValue}
+              setCurrentValue={setCurrentValue}
+            />
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="title" content="추천하는 책" />

--- a/client/src/pages/Curation/CurationWritePage.tsx
+++ b/client/src/pages/Curation/CurationWritePage.tsx
@@ -51,6 +51,7 @@ const CurationWritePage = () => {
   const navigate = useNavigate();
 
   const [categoryId, setCategoryId] = useState<number>(0);
+  const [currentValue, setCurrentValue] = useState<string>('카테고리를 선택하세요');
 
   const handleValidation = () => {
     if (!emojiValue) {
@@ -196,7 +197,11 @@ const CurationWritePage = () => {
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="title" content="카테고리" />
-            <SelectBox setCategoryId={setCategoryId} />
+            <SelectBox
+              setCategoryId={setCategoryId}
+              currentValue={currentValue}
+              setCurrentValue={setCurrentValue}
+            />
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="title" content="추천하는 책" />

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,13 +1,14 @@
 export enum ModalType {
-    WELCOME= 'welcome',
-	SUBSCRIBE='subscribe',
+  WELCOME = 'welcome',
+  SUBSCRIBE = 'subscribe',
+  REPLY = 'reply',
 }
 
-export enum CurationType{
-    MYPAGE= 'mypage',
-    LIST='list',
+export enum CurationType {
+  MYPAGE = 'mypage',
+  LIST = 'list',
 }
-export enum UserPageType{
-    MYPAGE='mypage',
-    USERPAGE='userpage',
+export enum UserPageType {
+  MYPAGE = 'mypage',
+  USERPAGE = 'userpage',
 }


### PR DESCRIPTION
## 개요
단일 큐레이션 상세페이지에서의 오류와 편집 페이지에서 카테고리, 책 정보 불러오는 기능을 처리하였습니다.

## 작업사항
- 댓글 삭제 아이콘 클릭시 댓글 삭제 확인 모달 창을 띄우고 그 모달의 댓글 삭제 버튼을 눌러야 삭제되는 로직으로 변경하였습니다.
- 삭제시 블랙화면이 꽉차게끔 너비와 높이를 변경하였습니다.
- 편집 페이지에서 카테고리와 책 정리를 불러오는 부분을 수정하면서, 연관된 작성 페이지와 태그 박스 컴포넌트의 코드를 수정하였습니다.

## 참고사항
 - 뒤로 가기 시 undefined 로 나오는 것은 아직 해결을 못했고 주말에 진행해봐야 할 것 같습니다. (이 부분 도와주시면 감사하겠습니다.)
 
## 스크린샷
- 댓글 삭제기능
![댓삭](https://github.com/codestates-seb/seb44_main_004/assets/76391160/d38bd4e5-ccf2-4428-bacc-b010f1251409)

- 글 작성 후, 편집 완료
![편집 페이지](https://github.com/codestates-seb/seb44_main_004/assets/76391160/cfd39623-26ba-481d-a8e3-28872c9195ea)

## 리뷰 요청사항
- 참고사항의 예외 처리 이외에 추가로 예외 처리가 필요한 부분이 있을 지 조언 부탁드립니다.