### PR TITLE
마이페지이지 리팩토링 - border 제거, 탈퇴 확인 모달

### DIFF
--- a/client/src/components/modals/Modal.tsx
+++ b/client/src/components/modals/Modal.tsx
@@ -9,6 +9,8 @@ interface ModalProps {
   handleCloseModal: () => void;
   handleCancelSubscribe?: () => void;
   handleCompleteCommentDelete?: () => void;
+  handleCompleteOut?: () => void;
+  handleCompleteUpdate?: () => void;
   nickname?: string;
 }
 const Modal = ({
@@ -16,12 +18,14 @@ const Modal = ({
   handleCloseModal,
   handleCancelSubscribe,
   handleCompleteCommentDelete,
+  handleCompleteOut,
   nickname,
 }: ModalProps) => {
   const title: Array<string> = [
     '후즈북의 큐레이터가 되신것을 환영합니다!',
     `${nickname}님의 큐레이션 구독을 취소하시겠어요?`,
     `댓글을 정말 삭제하시겠습니까?`,
+    `${nickname} 님, 정말 회원을 탈퇴하시겠어요?`,
   ];
   const renderingModal = () => {
     switch (type) {
@@ -76,6 +80,30 @@ const Modal = ({
             </ButtonZone>
           </>
         );
+        break;
+      case ModalType.OUT:
+        return (
+          <>
+            <ModalTitle>{title[3]}</ModalTitle>
+            <ButtonZone>
+              <Button
+                type="cancel"
+                content="탈퇴"
+                onClick={handleCompleteOut}
+                width="calc(30%-0.5rem)"
+              />
+              <Button
+                type="basic"
+                content="닫기"
+                onClick={handleCloseModal}
+                width="calc(40%-0.5rem)"
+              />
+            </ButtonZone>
+          </>
+        );
+        break;
+      default:
+        break;
     }
   };
   return (

--- a/client/src/components/profiles/ProfileInfo.tsx
+++ b/client/src/components/profiles/ProfileInfo.tsx
@@ -175,9 +175,6 @@ const ProfileInfoContainer = tw.section`
     flex
     justify-between
     py-10
-    border-b-2
-    border-solid
-    border-gray-300
     gap-[3rem]
 `;
 

--- a/client/src/components/profiles/ProfileOut.tsx
+++ b/client/src/components/profiles/ProfileOut.tsx
@@ -42,7 +42,7 @@ const ProfileOut = () => {
       <Info>
         <Point>{myInfo.mySubscriber}</Point> 명의 구독자를 보유하고 계세요.
       </Info>
-      <Info>BEST 큐레이터가 되는 것을 포기하시겠어요?</Info>
+      <Info>BEST 큐레이터가 될 기회를 포기하시겠어요?</Info>
       <ButtonZone>
         <Button type="detail" content="포기하고 탈퇴하기" width="10rem" onClick={handleModal} />
         <Button type="detail" content="포기하지 않고 도전하기" width="10rem" onClick={handleBack} />

--- a/client/src/components/profiles/ProfileOut.tsx
+++ b/client/src/components/profiles/ProfileOut.tsx
@@ -35,7 +35,7 @@ const ProfileOut = () => {
       <Info>
         <Point>{myInfo.mySubscriber}</Point> 명의 구독자를 보유하고 계세요.
       </Info>
-      <Info>최고의 큐레이터가 되는 것을 포기하시겠어요?</Info>
+      <Info>BEST 큐레이터가 되는 것을 포기하시겠어요?</Info>
       <ButtonZone>
         <Button type="detail" content="포기하고 탈퇴하기" width="10rem" onClick={handleOut} />
         <Button type="detail" content="포기하지 않고 도전하기" width="10rem" onClick={handleBack} />
@@ -50,17 +50,16 @@ const ProfileOutContainer = styled.div`
   align-items: center;
 `;
 const Point = styled.div`
-  font-size: 1.5rem;
+  font-size: 1.3rem;
   font-weight: 700;
   color: ${({ theme }) => theme.colors.mainLogoColor};
   padding-right: 1rem;
 `;
 const Info = styled.div`
   display: flex;
-  align-items: flex-end;
-  font-size: 1.5rem;
-
-  margin: 1rem;
+  align-items: center;
+  font-size: 1rem;
+  margin: 0.8rem;
   &:nth-last-child(2) {
     margin-top: 3rem;
     margin-bottom: 2rem;
@@ -80,6 +79,8 @@ const ButtonZone = styled.div`
     background-color: black;
     color: white;
     &:hover {
+      background-color: white;
+      color: black;
     }
   }
 `;

--- a/client/src/components/profiles/ProfileOut.tsx
+++ b/client/src/components/profiles/ProfileOut.tsx
@@ -1,14 +1,17 @@
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
+import { useState } from 'react';
 import Button from '../buttons/Button';
+import Modal from '../modals/Modal';
+import { ModalType } from '../../types';
 import { useNavigate } from 'react-router-dom';
 import { memberOutAPI } from '../../api/profileApi';
 import { customAlert } from '../alert/sweetAlert';
 const ProfileOut = () => {
   const myInfo = useSelector((state: RootState) => state.user);
   const navigate = useNavigate();
-
+  const [isModal, setIsModal] = useState<boolean>(false);
   const handleOut = async () => {
     const response = await memberOutAPI();
     if (response?.status === 204) {
@@ -19,7 +22,11 @@ const ProfileOut = () => {
         confirmButtonText: '성공',
         confirmButtonColor: 'black',
       });
+      navigate('/');
     }
+  };
+  const handleModal = () => {
+    setIsModal(!isModal);
   };
   const handleBack = () => {
     navigate('/mypage');
@@ -37,9 +44,17 @@ const ProfileOut = () => {
       </Info>
       <Info>BEST 큐레이터가 되는 것을 포기하시겠어요?</Info>
       <ButtonZone>
-        <Button type="detail" content="포기하고 탈퇴하기" width="10rem" onClick={handleOut} />
+        <Button type="detail" content="포기하고 탈퇴하기" width="10rem" onClick={handleModal} />
         <Button type="detail" content="포기하지 않고 도전하기" width="10rem" onClick={handleBack} />
       </ButtonZone>
+      {isModal && (
+        <Modal
+          type={ModalType.OUT}
+          handleCloseModal={handleModal}
+          handleCompleteOut={handleOut}
+          nickname={myInfo?.nickname}
+        />
+      )}
     </ProfileOutContainer>
   );
 };

--- a/client/src/pages/User/MyPage.tsx
+++ b/client/src/pages/User/MyPage.tsx
@@ -99,7 +99,10 @@ export const ProfileDetailContainer = styled.section`
         flex
         justify-center
         mt-[3rem]
+
     `}
+  border-top: 0.08rem solid gray;
+  padding-top: 4rem;
   @media (max-width: 1000px) {
     flex-direction: column;
   }

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -2,6 +2,7 @@ export enum ModalType {
   WELCOME = 'welcome',
   SUBSCRIBE = 'subscribe',
   REPLY = 'reply',
+  OUT = 'out',
 }
 
 export enum CurationType {


### PR DESCRIPTION
## 개요
마이페이지에서 생긴 이슈에 대한 리팩토링입니다.

## 작업사항
- reset 주석으로 인한 마이페이지 상단 div 에 border 를 제거하였습니다.
- 제거 함에 따라 새롭게 css 를 수정하여 구분선을 만들었습니다.
- 회원 탈퇴시 모달을 띄워 한 번 더 확인 후 탈퇴를 할 수 있도록 하였습니다.
- 그에 따른 Modal 컴포넌트에서 회원 탈퇴의 경우를 추가하였습니다.
  - ```Modal``` 컴포넌트에서 ```handleCompleteOut``` 함수 추가
  - ```type/index.ts``` 파일에서 ```ModalType``` 에 ```OUT=out``` 추가
- 탈퇴 시 문구는 'BEST 큐레이터가 될 기회를 포기하시겠어요?'로 변경하였습니다.

## 참고사항
- 탈퇴 테스트를 진행하였습니다. 로컬에서 데이터가 날라가는 것에 대해 한 건만 테스트를 실행한 것에 있어서 양해부탁드립니다.
- 회원 수정 사항시 모달을 띄우는 것에 대한 의견에 코드를 반영하고자 하였으나, form 태그에 대한 onSubmit 이 연결되어 있어 모달을 띄웠음에도 불구하고 저절로 업데이트 되는 현상으로 모달을 띄우지 않는 것으로 결정하였습니다. 혹여나 시간이 난다면 이 점은 추후에 적용시켜보도록 하겠습니다.

## 스크린샷
![image](https://github.com/codestates-seb/seb44_main_004/assets/76391160/afd0a163-120d-414d-a694-5484e857bec4)
![image](https://github.com/codestates-seb/seb44_main_004/assets/76391160/d1258ee1-b45c-42be-a17d-110192eeab0b)


## 리뷰 요청사항
- 참고사항의 예외 처리 이외에 추가로 예외 처리가 필요한 부분이 있을 지 조언 부탁드립니다.