### PR TITLE
[Client] Quill Editor 기능 추가 및 버그 수정

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="./public/favicon.ico" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/react-quill@1.3.3/dist/quill.bubble.css"
+      href="https://unpkg.com/react-quill@1.3.3/dist/quill.snow.css"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Whose Book</title>

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -1,6 +1,6 @@
 import { MutableRefObject, useMemo, memo } from "react";
 import ReactQuill from 'react-quill';
-import 'react-quill/dist/quill.bubble.css';
+import 'react-quill/dist/quill.snow.css';
 import { axiosInstance } from '../../api/axios';
 
 type QuillEditorProps = {
@@ -94,15 +94,15 @@ const QuillEditor = memo (({ quillRef, contentValue, setContentValue }: QuillEdi
         onChange={setContentValue}
         modules={modules}
         formats={formats}
-        theme="bubble"
+        theme="snow"
         placeholder="큐레이션의 내용을 입력해 주세요"
         style={{
-          fontWeight: "100",
-          marginBottom: '0.3rem',
+          // fontWeight: "100",
+          // marginBottom: '4rem',
           backgroundColor: '#f8f7f7',
           border: 'none',
-          borderRadius: '0.3rem',
-          height: '18.75rem',
+          // borderRadius: '0.3rem',
+          // height: '18.75rem',
         }}
       />
     </>

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -70,7 +70,8 @@ const QuillEditor = memo (({ quillRef, contentValue, setContentValue }: QuillEdi
         },
       },
     }),
-    []);
+    []
+  );
 
     const formats = [
       'header',
@@ -84,6 +85,25 @@ const QuillEditor = memo (({ quillRef, contentValue, setContentValue }: QuillEdi
 
   return (
     <>
+      <style>
+        {`
+          .ql-toolbar {
+            border: none !important;
+            border-radius: 0.3rem 0.3rem 0rem 0rem;
+            background-color: #f8f7f7;
+          }
+          .ql-container.ql-snow {
+            border: none !important;
+            border-radius: 0rem 0rem 0.3rem 0.3rem;
+
+            background-color: #f8f7f7;
+            height: 18.75rem;
+          }
+          .ql-editor .ql-placeholder {
+            font-style: normal;
+          }
+        `}
+      </style>
       <ReactQuill
         ref={(element) => {
           if (element !== null) {
@@ -96,14 +116,6 @@ const QuillEditor = memo (({ quillRef, contentValue, setContentValue }: QuillEdi
         formats={formats}
         theme="snow"
         placeholder="큐레이션의 내용을 입력해 주세요"
-        style={{
-          // fontWeight: "100",
-          // marginBottom: '4rem',
-          backgroundColor: '#f8f7f7',
-          border: 'none',
-          // borderRadius: '0.3rem',
-          // height: '18.75rem',
-        }}
       />
     </>
   );

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -1,7 +1,8 @@
-import { MutableRefObject, useMemo, memo } from 'react';
+import { MutableRefObject, useMemo, memo, useEffect } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import { axiosInstance } from '../../api/axios';
+import { customAlert } from '../../components/alert/sweetAlert';
 
 type QuillEditorProps = {
   quillRef: MutableRefObject<ReactQuill | null>;
@@ -10,47 +11,62 @@ type QuillEditorProps = {
 };
 
 const QuillEditor = memo(({ quillRef, contentValue, setContentValue }: QuillEditorProps) => {
-  const imageHandler = () => {
+  const imageHandler = async () => {
     const input = document.createElement('input');
     const formData = new FormData();
     const { VITE_AUTH_KEY } = import.meta.env;
-
+  
     input.setAttribute('type', 'file');
     input.setAttribute('accept', 'image/*');
     input.click();
-
-    input.onchange = async () => {
-      const file = input.files;
-      if (file !== null) {
-        formData.append('curationImage', file[0]);
-
-        try {
-          const response = await axiosInstance.post(
-            'http://localhost:8080/curations/images/upload',
-            formData,
-            {
-              headers: {
-                Authorization: `${VITE_AUTH_KEY}`,
-              },
-            }
-          );
-          const imageUrl = response.data.imageUrl;
-
-          const range = quillRef.current?.getEditor().getSelection()?.index;
-          if (range !== null && range !== undefined) {
-            const quill = quillRef.current?.getEditor();
-            quill?.setSelection(range, 1);
-            quill?.clipboard.dangerouslyPasteHTML(
-              range,
-              `<img src="${imageUrl}" alt="curation image tag." />`
-            );
-          }
-          return { ...response, success: true };
-        } catch (error) {
-          console.error(error);
+  
+    const file = await new Promise<File | null>((resolve) => {
+      input.onchange = () => {
+        if (input.files !== null) {
+          resolve(input.files[0]);
+        } else {
+          resolve(null);
         }
+      };
+    });
+
+    const maxSize = 2 * 1024 * 1024;
+    if (file && file.size > maxSize) {
+      customAlert({
+        title: '이미지 파일 사이즈를 확인해주세요!',
+        text: '이미지 파일은 2MB 이하로만 등록 가능합니다 :)',
+        icon: 'warning',
+        confirmButtonText: '확인',
+        confirmButtonColor: '#F1C93B',
+      });
+      return;
+    }
+  
+    if (file) {
+      formData.append('curationImage', file);
+
+      try {
+        const response = await axiosInstance.post(
+          'http://localhost:8080/curations/images/upload',
+          formData,
+          {
+            headers: {
+              Authorization: `${VITE_AUTH_KEY}`,
+            },
+          }
+        );
+        const imageUrl = response.data.imageUrl;
+
+        const editor = quillRef.current?.getEditor();
+        const range = editor?.getSelection()?.index;
+        if (range !== null && range !== undefined) {
+          editor?.insertEmbed(range, 'image', imageUrl);
+        }
+        return { ...response, success: true };
+      } catch (error) {
+        console.error(error);
       }
-    };
+    }
   };
 
   const modules = useMemo(
@@ -72,6 +88,43 @@ const QuillEditor = memo(({ quillRef, contentValue, setContentValue }: QuillEdit
   );
 
   const formats = ['header', 'bold', 'italic', 'underline', 'strike', 'blockquote', 'image'];
+
+  useEffect(() => {
+    const editor = quillRef.current?.getEditor();
+    if (editor) {
+      const quillEditor = editor.getModule('clipboard');
+      quillEditor.addMatcher('img', (node: { tagName: string }, delta: unknown) => {
+        if (node.tagName && node.tagName.toUpperCase() === 'IMG') {
+          return null;
+        }
+        return delta;
+      });
+
+      const handlePaste = (e: React.ClipboardEvent<HTMLElement>) => {
+        const clipboardData = e.clipboardData as DataTransfer;
+        if (clipboardData.types.includes('Files')) {
+          e.preventDefault();
+          customAlert({
+            title: '이미지 붙여넣기는 지원되지 않아요',
+            text: '이미지 버튼을 눌러 업로드 해주세요',
+            icon: 'warning',
+            confirmButtonText: '확인',
+            confirmButtonColor: '#F1C93B',
+          });
+        } else {
+          const textData = clipboardData.getData('text/plain');
+          setContentValue(textData);
+          e.preventDefault();
+        }
+      };
+      editor.root.addEventListener('paste', handlePaste as unknown as EventListener);
+
+      return () => {
+        editor.root.removeEventListener('paste', handlePaste as unknown as EventListener);
+      };
+    }
+  }, [quillRef, setContentValue]);
+
 
   return (
     <>
@@ -95,25 +148,17 @@ const QuillEditor = memo(({ quillRef, contentValue, setContentValue }: QuillEdit
         `}
       </style>
       <ReactQuill
-        ref={(element) => {
+        ref={(element: ReactQuill | null) => {
           if (element !== null) {
             quillRef.current = element;
           }
         }}
-        value={contentValue}
-        onChange={setContentValue}
         modules={modules}
         formats={formats}
         theme="snow"
         placeholder="큐레이션의 내용을 입력해 주세요"
-        style={{
-          fontWeight: '100',
-          marginBottom: '0.3rem',
-          backgroundColor: '#f8f7f7',
-          border: 'none',
-          borderRadius: '0.3rem',
-          height: '18.75rem',
-        }}
+        value={contentValue}
+        onChange={setContentValue}
       />
     </>
   );

--- a/client/src/components/quill/QuillEditor.tsx
+++ b/client/src/components/quill/QuillEditor.tsx
@@ -92,14 +92,6 @@ const QuillEditor = memo(({ quillRef, contentValue, setContentValue }: QuillEdit
   useEffect(() => {
     const editor = quillRef.current?.getEditor();
     if (editor) {
-      const quillEditor = editor.getModule('clipboard');
-      quillEditor.addMatcher('img', (node: { tagName: string }, delta: unknown) => {
-        if (node.tagName && node.tagName.toUpperCase() === 'IMG') {
-          return null;
-        }
-        return delta;
-      });
-
       const handlePaste = (e: React.ClipboardEvent<HTMLElement>) => {
         const clipboardData = e.clipboardData as DataTransfer;
         if (clipboardData.types.includes('Files')) {
@@ -113,10 +105,19 @@ const QuillEditor = memo(({ quillRef, contentValue, setContentValue }: QuillEdit
           });
         } else {
           const textData = clipboardData.getData('text/plain');
-          setContentValue(textData);
-          e.preventDefault();
+          if (textData) {
+            const selection = editor.getSelection();
+            if (selection) {
+              e.preventDefault();
+            }
+          }
         }
       };
+
+      editor.clipboard.addMatcher('br', (node, delta) => {
+        return delta;
+      });
+
       editor.root.addEventListener('paste', handlePaste as unknown as EventListener);
 
       return () => {
@@ -124,8 +125,7 @@ const QuillEditor = memo(({ quillRef, contentValue, setContentValue }: QuillEdit
       };
     }
   }, [quillRef, setContentValue]);
-
-
+  
   return (
     <>
       <style>

--- a/client/src/styles/GlobalStyles.ts
+++ b/client/src/styles/GlobalStyles.ts
@@ -1,8 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
-import reset from 'styled-reset';
 
 const GlobalStyles = createGlobalStyle` 
-  ${reset}
 
   @font-face {
     font-family: 'SpoqaHanSansNeo-Regular';


### PR DESCRIPTION
## 개요

- Quill 기능 추가 및 버그 수정

## 작업사항

- Editor에서 작성 후 큐레이션 단일 상세페이지에서 bold, italic, heading 등 **스타일 적용이 되지 않은 버그를 해결**했습니다.
- 드래그해야 이미지를 넣을 수 있었던 점은 **Quill 테마 변경**을 하여 드래그하지 않아도 **이미지 버튼이 보이게끔 수정**했습니다.
- **이미지 붙여넣기 금지 기능**을 추가했고, 붙여넣기 시 customAlert을 띄워 주었습니다.
- **이미지는 2MB 이하로 업로드** 되도록 제한을 걸어두었고, 용량 초과 시 `customAlert`을 띄워 주었습니다.

## 참고사항

- 지난 멘토링 때 멘토님이 텍스트까지 붙여넣기 불가할까 우려하셨으나, 다행히 **이미지만 붙여넣기 불가하도록 구현**할 수 있었습니다.
- 코드가 살짝 뒤죽박죽인데, 우선 기능구현 먼저 하고 추후에 리팩토링 진행하겠습니다.
- 아래 영상에서는 이미지 업로드 속도가 살짝 느린데, 현재 제 로컬에서 네트워크 속도 자체가 느린 점 참고해 주세요!

## 스크린샷

https://github.com/codestates-seb/seb44_main_004/assets/123397411/3aeab0a8-b424-4551-99f0-1aac191b7336


## 리뷰 요청사항

- 피드백은 언제든지 환영입니다.
