### PR TITLE
마이페이지 추가 이슈 리팩토링

### DIFF
--- a/client/src/components/profiles/CuratorList.tsx
+++ b/client/src/components/profiles/CuratorList.tsx
@@ -4,6 +4,7 @@ import ProfileCard from './ProfileCard';
 import ClockLoading from '../Loading/ClockLoading';
 import { CuratorProps } from '../../types/card';
 import { getSubscribersAPI } from '../../api/profileApi';
+import { Comment } from './WrittenList';
 
 const loadingStyle = {
   height: '15vh',
@@ -62,7 +63,7 @@ const CuraotrList = () => {
           />
         </>
       ) : (
-        <div>데이터가 없습니다..</div>
+        <Comment>아직 구독한 큐레이터가 없어요 😂</Comment>
       )}
     </>
   );

--- a/client/src/components/profiles/LikeList.tsx
+++ b/client/src/components/profiles/LikeList.tsx
@@ -6,6 +6,7 @@ import ClockLoading from '../Loading/ClockLoading';
 import { UserPageType } from '../../types';
 import { CurationProps } from '../../types/card';
 import { getLikeCuratoionsAPI, getUserLikeCurationsAPI } from '../../api/profileApi';
+import { Comment } from './WrittenList';
 
 interface LikeListProps {
   type: UserPageType;
@@ -73,7 +74,7 @@ const LikeList = ({ type }: LikeListProps) => {
           />
         </>
       ) : (
-        <div>데이터가 없습니다..</div>
+        <Comment>아직 좋아요한 큐레이션이 없어요 😂</Comment>
       )}
     </>
   );

--- a/client/src/components/profiles/ProfileInfo.tsx
+++ b/client/src/components/profiles/ProfileInfo.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import tw from 'twin.macro';
 import styled from 'styled-components';
@@ -19,13 +19,14 @@ import {
   deleteSubscribeAPI,
   getMyInfoAPI,
 } from '../../api/profileApi';
+import { RootState } from '../../store/store';
 
 const ProfileInfo = ({ type }: ProfileTypeProps) => {
   const [myInfo, setMyInfo] = useState<MyProps>();
   const [userInfo, setUserInfo] = useState<UserProps>();
   const [isSubscribe, setIsSubscribe] = useState<boolean>();
   const [isModal, setIsModal] = useState<boolean>(false);
-
+  const user = useSelector((state: RootState) => state.user);
   const { memberId } = useParams();
 
   const token = localStorage.getItem('Authorization');
@@ -90,6 +91,9 @@ const ProfileInfo = ({ type }: ProfileTypeProps) => {
     if (response) {
       setUserInfo(response.data);
       setIsSubscribe(response.data.subscribed);
+      if (userInfo?.memberId === user?.memberId) {
+        navigate('/mypage');
+      }
     }
   };
 

--- a/client/src/components/profiles/ProfileOut.tsx
+++ b/client/src/components/profiles/ProfileOut.tsx
@@ -20,7 +20,7 @@ const ProfileOut = () => {
         text: '서비스를 사용하고 싶으시다면, 다시 회원이 되어주세요.',
         icon: 'success',
         confirmButtonText: '성공',
-        confirmButtonColor: 'black',
+        confirmButtonColor: '#F1C93B',
       });
       navigate('/');
     }

--- a/client/src/components/profiles/WrittenList.tsx
+++ b/client/src/components/profiles/WrittenList.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
+import styled from 'styled-components';
+
 import ProfileCuration from './ProfileCard';
 import ClockLoading from '../Loading/ClockLoading';
 import { UserPageType } from '../../types';
@@ -72,9 +74,14 @@ const WrittenList = ({ type }: WrittenListProps) => {
           />
         </>
       ) : (
-        <div>데이터가 없습니다..</div>
+        <Comment>아직 작성한 큐레이션이 없어요 😂</Comment>
       )}
     </>
   );
 };
+export const Comment = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-top: 5rem;
+`;
 export default WrittenList;

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -12,7 +12,7 @@ export interface MyProps {
 }
 
 export interface UserProps {
-  memgerId: number;
+  memberId: number;
   email: string;
   nickname: string;
   introduction: string | null;


### PR DESCRIPTION
- 작성한 큐레이션, 좋아욯나 큐레이션, 구독한 큐레이터 목록에서 데이터가 없을 때 문구 변경
- 마이페이지가 아닌 BEST 큐레이터나 단일 상세 큐레이션 페이지에서 닉네임을 클릭해서 자기 자신의 페이지에 접속했을 때, 마이페이지가 아닌 유저 페이지로 나오는 이슈 (구독하기 버튼 생성) -> 마이페이지로 다시 이동