### PR TITLE
프로필 이미지 리팩토링

### DIFF
--- a/client/src/components/curations/CurationProfileInfo.tsx
+++ b/client/src/components/curations/CurationProfileInfo.tsx
@@ -140,6 +140,7 @@ const ProfileImage = tw.div`
 const DefaultImg = styled.img`
   height: inherit;
   object-fit: cover;
+  width: 100%;
 `;
 
 const Nickname = tw.p`

--- a/client/src/components/profiles/ProfileInfo.tsx
+++ b/client/src/components/profiles/ProfileInfo.tsx
@@ -205,6 +205,7 @@ const ProfileImage = tw.div`
 const DefaultImg = styled.img`
   height: inherit;
   object-fit: cover;
+  width: 100%;
 `;
 const Nickname = tw.p`
     text-3xl


### PR DESCRIPTION
- 마이페이지에서 프로필과 단일 큐레이션 상세 페이지에서 프로필 이미지를 꽉 차게 height 를 변경하였습니다.
- (정사각형이 아닌 직사각형의 이미지를 업로드 시 )

|변경 전| 변경 후|
|:--:|:--:|
|![image](https://github.com/codestates-seb/seb44_main_004/assets/76391160/7232397b-34aa-4ad2-81bb-212e94de32f9)|![image](https://github.com/codestates-seb/seb44_main_004/assets/76391160/81715b8b-59d6-4a53-a958-5b20f49fa3fd)|

