### PR TITLE
[Client] 큐레이션 단일 상세 조회 페이지 스타일 수정

### DIFF
--- a/client/src/components/curations/CurationCreatedDate.tsx
+++ b/client/src/components/curations/CurationCreatedDate.tsx
@@ -18,7 +18,7 @@ interface CurationCreatedDateProps {
 const CurationCreatedDate: React.FC<CurationCreatedDateProps> = ({ createdAt }) => {
   const formattedDateTime = convertDateTimeFormat(createdAt);
 
-  return <CreatedDate>업로드 : {formattedDateTime}</CreatedDate>;
+  return <CreatedDate className='created-date'> 업로드 : {formattedDateTime}</CreatedDate>;
 };
 
 const CreatedDate = styled.div`

--- a/client/src/components/profiles/ProfileInfo.tsx
+++ b/client/src/components/profiles/ProfileInfo.tsx
@@ -157,7 +157,7 @@ const ProfileInfo = ({ type }: ProfileTypeProps) => {
 
         <UserIntroduce>
           {(type === UserPageType.MYPAGE ? myInfo?.introduction : userInfo?.introduction) ||
-            '아직 소개글이 없습니다.'}
+            '아직 소개글이 없어요 😂'}
         </UserIntroduce>
       </ProfileInfoLeft>
 

--- a/client/src/components/replies/ReplyCreatedDate.tsx
+++ b/client/src/components/replies/ReplyCreatedDate.tsx
@@ -10,7 +10,7 @@ const createdDate = new Date().toLocaleString('ko-KR', {
 
 const ReplyCreatedDate = () => {
   return (
-    <CreatedDate>
+    <CreatedDate className="created-date">
       {createdDate.replace(',', '')}
     </CreatedDate>
   )

--- a/client/src/components/replies/ReplyProfileInfo.tsx
+++ b/client/src/components/replies/ReplyProfileInfo.tsx
@@ -37,10 +37,10 @@ const ReplyProfileInfo = ({
         {memberId === replierId && (
           <>
             <EditButton onClick={() => handleCommentEdit(content)}>
-              <HiPencil size="1.5rem" />
+              <HiPencil size="1.3rem" />
             </EditButton>
             <DelteButton onClick={() => handleCommentDelete(replyId)}>
-              <HiTrash size="1.5rem" />
+              <HiTrash size="1.3rem" />
             </DelteButton>
           </>
         )}
@@ -78,9 +78,8 @@ const DefaultImg = styled.img`
 `;
 
 const Nickname = tw.p`
-    text-xl
+    text-lg
     font-thin
-    
 `;
 const ButtonZone = tw.div`
     flex

--- a/client/src/pages/Curation/CurationDetailPage.tsx
+++ b/client/src/pages/Curation/CurationDetailPage.tsx
@@ -354,7 +354,7 @@ const CurationDetailPage = () => {
                   <CurationCreatedDate createdAt={curation.createdAt} />
                 </DetailInfoRight>
               </GridContainer>
-              <ContentContainer>
+              <ContentContainer className="content-container">
                 <div dangerouslySetInnerHTML={{ __html: `${curation.content}` }} />
               </ContentContainer>
 
@@ -391,7 +391,7 @@ const CurationDetailPage = () => {
                   replies?.map((e, idx: number) => {
                     const isEditing = editingIndexes[idx];
                     return (
-                      <ReplyContainer key={idx}>
+                      <ReplyContainer key={idx} className="reply-container">
                         {isEditing ? (
                           <EditContainer key={`edit ${idx}`}>
                             <UserInfo>
@@ -438,7 +438,7 @@ const CurationDetailPage = () => {
                     );
                   })
                 ) : (
-                  <Comment>아직 댓글이 없어요.😂</Comment>
+                  <Comment className="reply-container">첫 댓글의 큐레이터가 되어 주세요 😊</Comment>
                 )}
               </ItemContainer>
 
@@ -480,14 +480,13 @@ const FormContainer = styled.div`
   background-color: #ffffff;
   border-radius: 1rem;
   padding: 0rem 3rem 2rem 3rem;
-  width: 80rem;
+  width: 60rem;
   margin-bottom: 8rem;
 `;
 
 const TitleContainer = styled.div`
   display: flex;
   align-items: center;
-  /* justify-content: space-between; */
   flex-direction: row;
   margin: 4rem 0rem 2rem 0rem;
   text-align: left;
@@ -559,8 +558,8 @@ const DetailInfoRight = styled.div`
 const ContentContainer = styled.div`
   margin: 3rem 0rem;
   text-align: left;
-  font-size: 1.2rem;
-  line-height: 2rem;
+  font-size: 1rem;
+  line-height: 1.7rem;
   img {
     max-width: 100%;
     height: auto;
@@ -577,6 +576,7 @@ const ItemContainer = tw.div`
   [> label]:mb-4 
   [> button]:mb-3
 `;
+
 const UserInfo = tw.div`
     flex
     items-center
@@ -593,10 +593,12 @@ const ProfileImage = tw.div`
   justify-center
   border-solid border-[1px] border-gray-300
 `;
+
 const DefaultImg = styled.img`
   height: inherit;
   object-fit: cover;
 `;
+
 const CommentContainer = styled.div`
   width: 100%;
   margin: 0.4rem 0rem;
@@ -652,10 +654,12 @@ const ButtonZone = styled.div`
   justify-content: flex-end;
   margin-top: 1rem;
 `;
+
 const Nickname = tw.p`
     text-xl
     font-thin
 `;
+
 const Valid = tw.div`
     text-red-500
     pt-[0.5rem]
@@ -663,6 +667,7 @@ const Valid = tw.div`
     text-[0.7rem]
     font-semibold
 `;
+
 const ReplyContainer = tw.div``;
 
 const RepliesTitle = tw.label`

--- a/client/src/pages/Curation/CurationEditPage.tsx
+++ b/client/src/pages/Curation/CurationEditPage.tsx
@@ -246,11 +246,6 @@ const CurationEditPage = () => {
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="title" content="내용" />
-            <Label
-              type="content"
-              htmlFor="content"
-              content="마우스 드래그로 영역을 선택하면 서식을 수정하고, 이미지도 넣을 수 있어요!"
-            />
             <QuillEditor
               quillRef={quillRef}
               contentValue={curation?.content}

--- a/client/src/pages/Curation/CurationWritePage.tsx
+++ b/client/src/pages/Curation/CurationWritePage.tsx
@@ -199,11 +199,6 @@ const CurationWritePage = () => {
           </ItemContainer>
           <ItemContainer>
             <Label type="title" htmlFor="content" content="내용" />
-            <Label
-              type="content"
-              htmlFor="content"
-              content="마우스 드래그로 영역을 선택하면 서식을 수정하고, 이미지도 넣을 수 있어요!"
-            />
             <QuillEditor
               quillRef={quillRef}
               contentValue={contents}

--- a/client/src/styles/GlobalStyles.ts
+++ b/client/src/styles/GlobalStyles.ts
@@ -2,6 +2,13 @@ import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyles = createGlobalStyle` 
   @font-face {
+    font-family: 'SpoqaHanSansNeo-Light';
+    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Light.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+  }
+
+  @font-face {
     font-family: 'SpoqaHanSansNeo-Regular';
     src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Regular.woff') format('woff');
     font-weight: normal;
@@ -66,7 +73,7 @@ const GlobalStyles = createGlobalStyle`
   }
 
   .ql-editor strong {
-    font-weight:bold !important;
+    font-weight: bold !important;
   }
 
   .ql-editor em {
@@ -101,6 +108,15 @@ const GlobalStyles = createGlobalStyle`
 
   .slick-arrow .slick-prev {
     background-color: yellow;
+  }
+
+  .content-container, .reply-container {
+    font-family: 'SpoqaHanSansNeo-Light';
+  }
+
+  .created-date {
+    font-family: 'SpoqaHanSansNeo-Light';
+    font-size: 0.9rem;
   }
 `;
 


### PR DESCRIPTION
## 개요

- 전체적으로 다른 페이지들보다 크고 넓은 느낌이었던 큐레이션 단일 상세 조회 페이지를 수정

## 작업사항

- Quill Editor 테마 변경으로 작성/수정 페이지의 필요없는 **Label을 삭제**했습니다. (드래그해서 이미지 등록 가능하다는 문구)
- 전체적인 조회 페이지 Container의 **width를 줄였습니다.**
- 댓글과 큐레이션의 **업로드 일자의 텍스트** 및 **수정/삭제 아이콘의 크기**를 기존보다 줄였습니다.
- `ProfileInfo`의 소개글이 없다는 문구를 `~습니다` 체에서 `~요` 체로 통일했습니다.
- `ReplyProfileInfo`의 댓글 **내용 폰트 크기를 축소**했습니다.
- `GlobalStyles`에 컨텐츠, 댓글에 적용할 **SpoqaHanSansNeo-Light**을 추가했습니다.

## 참고사항

- 반응형 적용은 아직 작업중입니다.

## 스크린샷 (아이맥 기준 크롬 110%)

https://github.com/codestates-seb/seb44_main_004/assets/123397411/74368607-ae29-495d-b0ac-fcd12d06862a

![image](https://github.com/codestates-seb/seb44_main_004/assets/123397411/bffc522d-6c37-47bc-a7fb-4d91abee65b9)


## 리뷰 요청사항

- `CuratioinDetailPage` 스타일 작업이기에 지원님이 작업하신 부분의 스타일을 몇 가지 수정했는데, 의견 있으시면 말씀 부탁드립니다!
- 더불어, 여러분의 맥북에서도 너무 작아보이거나 여전히 커보이지 않는지 확인 부탁드립니다.


