### PR TITLE
fix: react-quill HTML태그들에서 모든 스타일 제거

### DIFF
--- a/client/src/components/cards/CurationCard.tsx
+++ b/client/src/components/cards/CurationCard.tsx
@@ -10,7 +10,7 @@ import { images } from '../../utils/importImgUrl';
 import { CurationProps } from '../../types/card';
 import { CurationType } from '../../types';
 import { RootState } from '../../store/store';
-import { removeStyleAngImgTags } from '../../utils/removeImgTags';
+import { removeStyleAndAttributes } from '../../utils/removeImgTags';
 
 const CurationCard = ({
   type,
@@ -42,7 +42,11 @@ const CurationCard = ({
       <CardContainer onClick={handleClick} type={type}>
         <Item>{emoji}</Item>
         <Item>{title}</Item>
-        <Item dangerouslySetInnerHTML={{ __html: removeStyleAngImgTags(content ?? '') }} />
+        <Item
+          dangerouslySetInnerHTML={{
+            __html: removeStyleAndAttributes(content ?? ''),
+          }}
+        />
         <Item>
           <ItemLeft>
             <LikeDiv>

--- a/client/src/components/cards/MainCurationCard.tsx
+++ b/client/src/components/cards/MainCurationCard.tsx
@@ -10,7 +10,7 @@ import { images } from '../../utils/importImgUrl';
 import { CurationProps } from '../../types/card';
 import { CurationType } from '../../types';
 import { RootState } from '../../store/store';
-import { removeStyleAngImgTags } from '../../utils/removeImgTags';
+import { removeStyleAndAttributes } from '../../utils/removeImgTags';
 
 const CurationCard = ({
   type,
@@ -41,7 +41,11 @@ const CurationCard = ({
       <CardContainer onClick={handleClick} type={type}>
         <Item>{emoji}</Item>
         <Item>{title}</Item>
-        <Item dangerouslySetInnerHTML={{ __html: removeStyleAngImgTags(content ?? '') }} />
+        <Item
+          dangerouslySetInnerHTML={{
+            __html: removeStyleAndAttributes(content ?? ''),
+          }}
+        />
         <Item>
           <ItemLeft>
             <LikeDiv>

--- a/client/src/utils/removeImgTags.ts
+++ b/client/src/utils/removeImgTags.ts
@@ -1,7 +1,7 @@
 /**
- * react-quill editor로 작성한 글 중 img 태그 부분 제외, style이 적용된 코드만 제외하고 content만 추출하는 함수
+ * react-quill editor로 작성한 글 중 img 태그 style이 적용된 코드만 제외하고 content만 추출하는 함수
  */
-export const removeStyleAngImgTags = (text: string) => {
+export const removeStyleImgTags = (text: string) => {
   const imgRegex = /<img[^>]*>/gi;
   const srcAltRegex = /\s(?:src|alt)\s*=\s*"[^"]*"/gi;
   const styleRegex = /\sstyle\s*=\s*"[^"]*"/gi;
@@ -10,4 +10,41 @@ export const removeStyleAngImgTags = (text: string) => {
   const removeStyle = removeImg.replace(styleRegex, '');
 
   return removeStyle;
+};
+
+/**
+ * react-quill editor의 HTML 문자열에서
+ *  - 이미지 태그의 src, alt 속성 제거
+ *  - 모든 태그에서 스타일 속성 제거
+ *  - <h1> ~ <h6> 모든 heading 태그를 <p> 태그로 대체
+ *  - <u> 태그 제거
+ *  - text-decoration: underline 스타일 제거
+ *  - text-decoration: line-through 스타일 제거
+ */
+export const removeStyleAndAttributes = (text: string) => {
+  const imgRegex = /<img[^>]*>/gi;
+  const srcAltRegex = /\s(?:src|alt)\s*=\s*"[^"]*"/gi;
+  const styleRegex = /\sstyle\s*=\s*"[^"]*"/gi;
+  const headingRegex = /<(\/?)h[1-6][^>]*>/gi;
+  const underlineRegex = /<(\/?)u>/gi;
+  const textDecorationUnderlineRegex = /text-decoration\s*:\s*underline;/gi;
+  const textDecorationLineThroughRegex = /text-decoration\s*:\s*line-through(;|\s*)?/gi;
+
+  const removeImgAttributes = text.replace(imgRegex, (match) => match.replace(srcAltRegex, ''));
+  const removeAllStyles = removeImgAttributes.replace(styleRegex, '');
+  const replaceHeadingsWithPTag = removeAllStyles.replace(
+    headingRegex,
+    (match, closingTag) => `<${closingTag}p>`
+  );
+  const removeUTag = replaceHeadingsWithPTag.replace(
+    underlineRegex,
+    (match, closingTag) => `<${closingTag}>`
+  );
+  const removeTextDecorationUnderline = removeUTag.replace(textDecorationUnderlineRegex, '');
+  const removeTextDecorationLineThrough = removeTextDecorationUnderline.replace(
+    textDecorationLineThroughRegex,
+    ''
+  );
+
+  return removeTextDecorationLineThrough;
 };


### PR DESCRIPTION
react-quill editor의 HTML 문자열에서
 - 이미지 태그의 src, alt 속성 제거
 - 모든 태그에서 스타일 속성 제거
 - <h1> ~ <h6> 모든 heading 태그를 <p> 태그로 대체
 - <u> 태그 제거
 - text-decoration: underline 스타일 제거
 - text-decoration: line-through 스타일 제거