### PR TITLE
feat: Unhandled Exception 슬랙 연동

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
 	// s3 이미지 업로드를 위한 의존성 추가
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
+
+	// 에러로그 슬랙 연동을 위한 의존성 추가
+	implementation 'com.slack.api:slack-api-client:1.29.0'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/seb_main_004/whosbook/advice/ErrorSlackConnectTestController.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/advice/ErrorSlackConnectTestController.java
@@ -1,0 +1,13 @@
+package com.seb_main_004.whosbook.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ErrorSlackConnectTestController {
+    @GetMapping("/error")
+    public ResponseEntity error() throws Exception {
+        throw new Exception("슬랙 연동하여 에러를 던지는 것을 테스트 합니다.");
+    }
+}

--- a/server/src/main/java/com/seb_main_004/whosbook/advice/GlobalExceptionAdvice.java
+++ b/server/src/main/java/com/seb_main_004/whosbook/advice/GlobalExceptionAdvice.java
@@ -2,6 +2,11 @@ package com.seb_main_004.whosbook.advice;
 
 import com.seb_main_004.whosbook.exception.BusinessLogicException;
 import com.seb_main_004.whosbook.response.ErrorResponse;
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -12,10 +17,23 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionAdvice {
+    // UnHandled Exception을 슬랙으로 연동하기 위한 설정
+    private final Slack slackClient = Slack.getInstance();
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -77,16 +95,50 @@ public class GlobalExceptionAdvice {
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ErrorResponse handleException(Exception e) {
-        System.out.println(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        System.out.println(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+    public ErrorResponse handleException(Exception e, HttpServletRequest request) {
+        log.error("UnhandledException: {} {} errMessage={}\n",
+                request.getMethod(),
+                request.getRequestURI(),
+                e.getMessage());
+
+        sendSlackAlertErrorLog(e, request);
 
         final ErrorResponse response = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
 
         return response;
     }
 
+    // 슬랙 알림을 보내는 메서드
+    private void sendSlackAlertErrorLog(Exception e, HttpServletRequest request) {
+        try {
+            slackClient.send(webhookUrl, payload(p -> p
+                    .text("서버 에러가 발생했습니다! 즉각확인 요망")
+                    .attachments(List.of(generateSlackAttachment(e, request)))));
+        } catch (IOException slackError) {
+            log.debug("Slack 통신 중 에러 발생 : {}", slackError.getMessage());
+        }
+    }
 
+    // attachments 생성메서드 : 슬랙의 메세지를 풍성하게 꾸며주는 역할
+    private Attachment generateSlackAttachment(Exception e, HttpServletRequest request) {
+        String requestTime = DateTimeFormatter.ofPattern("yyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now());
+        String xffHeader = request.getHeader("X-FORWARDED-FOR");
+        return Attachment.builder()
+                .color("ff0000")
+                .title(requestTime + "발생 에러 로그")
+                .fields(List.of(
+                        generateSlackField("Request IP", xffHeader == null ? request.getRemoteAddr() : xffHeader),
+                        generateSlackField("Request URL", request.getRequestURI() + " " + request.getMethod()),
+                        generateSlackField("Error Message", e.getMessage())
+                )).build();
+    }
 
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+                .title(title)
+                .value(value)
+                .valueShortEnough(false)
+                .build();
+    }
 
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -50,3 +50,7 @@ cloud:
     stack:
       auto: false
 
+# slack configuration
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL}


### PR DESCRIPTION
## 개요
- Exception 처리를 하지 않은 모든 Exception을 슬랙 알림으로 받을 수 있도록 연동

## 작업사항
- `build.gradle` 에 slack-api-client 의존성 추가 : 취약점 이슈가 없고 최근까지 업데이트가 일어남
- `GlobalExceptionAdvice` 에서 최종적으로 `Exception`을 잡는 부분에 Slack 전송 기능 추가
- 에러 테스트를 위한 요청시 무조건 에러를 던지는 컨트롤러 추가

### 참고사항
- 추후에는 `logback` 을 사용한 로그 적재, 분류등을 통해서 더욱 다양하게 구현 할 수 있을 것 같습니다.

### 스크린샷
<img width="322" alt="image" src="https://github.com/codestates-seb/seb44_main_004/assets/122109213/381f1349-daf8-4a62-bcad-2a233e76a469">

## 리뷰 요청사항
