### PR TITLE
fix: 회원탈퇴 시 알림 문구 변경, Sweet Alert 처리안된 부분 추가

### DIFF
--- a/client/src/api/axios.ts
+++ b/client/src/api/axios.ts
@@ -29,7 +29,7 @@ axiosInstance.interceptors.response.use(
         confirmButtonColor: '#3085d6',
         cancelButtonColor: '#777676',
         confirmButtonText: 'Login',
-        handleLoginPage: () => window.location.assign('/login'),
+        handleRoutePage: () => window.location.assign('/login'),
       });
     }
 

--- a/client/src/api/userApi.ts
+++ b/client/src/api/userApi.ts
@@ -27,15 +27,25 @@ export const loginAPI = async (data: IUserLoginData) => {
         confirmButtonText: '확인',
         confirmButtonColor: '#d33',
       });
-    } else {
-      customAlert({
-        title: '로그인 실패',
-        text: '이메일이 존재하지 않거나, 비밀번호가 불일치합니다.',
-        icon: 'error',
-        confirmButtonText: '확인',
-        confirmButtonColor: '#d33',
-      });
-      console.error(err);
+    } else if (
+      typeGuard<{ response: { data: { status: number; message: string } } }>(err, 'response') &&
+      err.response.data.status === 404
+    ) {
+      const { message } = err.response.data;
+
+      if (message === '이미 탈퇴한 사용자입니다.') {
+        console.error(err);
+        return;
+      } else {
+        customAlert({
+          title: '로그인 실패',
+          text: '이메일이 존재하지 않거나, 비밀번호가 불일치합니다.',
+          icon: 'error',
+          confirmButtonText: '확인',
+          confirmButtonColor: '#d33',
+        });
+        console.error(err);
+      }
     }
   }
 };
@@ -54,6 +64,7 @@ export const registerAPI = async (data: FormData) => {
       const { message } = err.response.data;
       let title = '';
       let text = '';
+
       if (message === '사용자가 이미 존재 합니다.') {
         title = '이미 가입된 이메일이네요!';
         text = '다른 이메일로 가입을 진행해주세요. :)';

--- a/client/src/components/alert/sweetAlert.ts
+++ b/client/src/components/alert/sweetAlert.ts
@@ -7,7 +7,7 @@ interface AlertSettings {
   confirmButtonColor?: string;
   cancelButtonColor?: string;
   confirmButtonText?: string;
-  handleLoginPage?: () => void | undefined;
+  handleRoutePage?: () => void | undefined;
 }
 
 export const customAlert = ({
@@ -18,7 +18,7 @@ export const customAlert = ({
   confirmButtonColor,
   cancelButtonColor,
   confirmButtonText,
-  handleLoginPage,
+  handleRoutePage,
 }: AlertSettings) => {
   Swal.fire({
     title,
@@ -30,7 +30,7 @@ export const customAlert = ({
     confirmButtonText,
   }).then((result) => {
     if (result.isConfirmed) {
-      if (handleLoginPage) handleLoginPage();
+      if (handleRoutePage) handleRoutePage();
     }
   });
   return;

--- a/client/src/components/curations/CurationDetailInfo.tsx
+++ b/client/src/components/curations/CurationDetailInfo.tsx
@@ -10,6 +10,7 @@ import { RootState } from '../../store/store';
 import { axiosInstance } from '../../api/axios';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { customAlert } from '../alert/sweetAlert';
 
 interface CurationDetailInfoProps {
   isLiked: boolean;
@@ -44,8 +45,16 @@ const CurationDetailInfo = ({
         setLikeCount(response.data.likeCount);
       }
     } else {
-      alert('좋아요 기능은 로그인 후에 가능합니다.');
-      navigate('/login', { state: { from: location.pathname } });
+      customAlert({
+        title: '로그인이 필요한 서비스입니다.',
+        text: '좋아요 기능은 로그인 후에 가능합니다.',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#777676',
+        confirmButtonText: 'Login',
+        handleRoutePage: () => navigate('/login', { state: { from: location.pathname } }),
+      });
     }
   };
   const handleCancelLike = async () => {

--- a/client/src/components/curations/CurationProfileInfo.tsx
+++ b/client/src/components/curations/CurationProfileInfo.tsx
@@ -12,6 +12,7 @@ import { ModalType } from '../../types';
 import { postSubscribeAPI, deleteSubscribeAPI } from '../../api/profileApi';
 import { useNavigate } from 'react-router-dom';
 import { itemsPerSize } from '../../types';
+import { customAlert } from '../alert/sweetAlert';
 
 interface CuratorProps {
   curator?: string;
@@ -45,8 +46,16 @@ const CurationProfileInfo: React.FC<CuratorProps> = ({
         setIsSubscribe(!isSubscribe);
       }
     } else {
-      alert('구독기능은 로그인 후에 가능합니다.');
-      navigate('/login', { state: { from: location.pathname } });
+      customAlert({
+        title: '로그인이 필요한 서비스입니다.',
+        text: '구독기능은 로그인 후에 가능합니다.',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#777676',
+        confirmButtonText: 'Login',
+        handleRoutePage: () => navigate('/login', { state: { from: location.pathname } }),
+      });
     }
   };
 

--- a/client/src/components/profiles/ProfileInfo.tsx
+++ b/client/src/components/profiles/ProfileInfo.tsx
@@ -66,7 +66,6 @@ const ProfileInfo = ({ type }: ProfileTypeProps) => {
       handleModal();
       setIsSubscribe(!isSubscribe);
     } else {
-      // alert('이미 구독을 취소한 상태입니다.');
       customAlert({
         title: '구독 실패',
         text: '이미 구독을 취소한 상태입니다.',

--- a/client/src/pages/Curation/BestCurationPage.tsx
+++ b/client/src/pages/Curation/BestCurationPage.tsx
@@ -98,7 +98,7 @@ const BestCurationPage = () => {
         confirmButtonColor: '#3085d6',
         cancelButtonColor: '#777676',
         confirmButtonText: 'Login',
-        handleLoginPage: () => navigate('/login'),
+        handleRoutePage: () => navigate('/login'),
       });
     }
   };

--- a/client/src/pages/Curation/NewCurationPage.tsx
+++ b/client/src/pages/Curation/NewCurationPage.tsx
@@ -101,7 +101,7 @@ const NewCurationPage = () => {
         confirmButtonColor: '#3085d6',
         cancelButtonColor: '#777676',
         confirmButtonText: 'Login',
-        handleLoginPage: () => navigate('/login'),
+        handleRoutePage: () => navigate('/login'),
       });
     }
   };

--- a/client/src/pages/User/SignIn.tsx
+++ b/client/src/pages/User/SignIn.tsx
@@ -10,6 +10,7 @@ import { VITE_OAUTH_GOOGLE_REDIRECT_URL } from '../../utils/envValiable';
 import Label from '../../components/label/Label';
 import Input from '../../components/input/Input';
 import Button from '../../components/buttons/Button';
+import { customAlert } from '../../components/alert/sweetAlert';
 
 const SignIn = () => {
   const navigate = useNavigate();
@@ -23,7 +24,6 @@ const SignIn = () => {
     username: false,
     password: false,
   });
-  /* const [keepLogin, setKeepLogin] = useState<boolean>(false); */
 
   const handleUpdateFormValue = (e: ChangeEvent<HTMLInputElement>) => {
     const { value, name } = e.target;
@@ -52,11 +52,21 @@ const SignIn = () => {
       const response = await loginAPI(data);
       if (response) {
         navigate(from);
+      } else {
+        customAlert({
+          title: '탈퇴한 계정으로 로그인하셨습니다.',
+          text: '다시 후즈북의 큐레이터가 되어주시겠어요?',
+          icon: 'info',
+          showCancelButton: true,
+          confirmButtonColor: '#91C8E4',
+          cancelButtonColor: '#777676',
+          confirmButtonText: '확인',
+          handleRoutePage: () => navigate('/register'),
+        });
       }
     }
   };
 
-  /** 배포된 서버에 oauth 적용되면 서버 주소로 변경 */
   const handleGoogleOAuthLogin = () => {
     window.location.href = VITE_OAUTH_GOOGLE_REDIRECT_URL;
   };


### PR DESCRIPTION
**버그 수정사항**

- 탈퇴한 계정으로 로그인하려고 할 때 Alert 처리, 회원가입 페이지로 갈것인지 체크
- 상세 페이지에서 로그인 하지 않았을 때 좋아요 누르면 Aelrt 처리, 로그인 페이지로 갈것인지 체크
- 상세 페이지에서  로그인 하지 않았을 때 구독하기 누르면 Aelrt 처리, 로그인 페이지로 갈것인지 체크